### PR TITLE
Add nmap and john builders

### DIFF
--- a/config/software/john.rb
+++ b/config/software/john.rb
@@ -1,0 +1,16 @@
+name "john"
+default_version "1.8.0"
+
+version("1.8.0") { source md5: "a4086df68f51778782777e60407f1869" }
+
+source url: "http://www.openwall.com/john/j/john-1.8.0.tar.xz"
+
+relative_path "john-#{version}/src"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  make env: env
+  make "clean generic", env: env
+  command "chmod +r #{project_dir}/../run/john.conf"
+  copy "#{project_dir}/../run/*", "#{install_dir}/embedded/bin/"
+end

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -15,6 +15,8 @@ dependency "nokogiri"
 dependency "ruby"
 dependency "postgresql"
 dependency "sqlite"
+dependency "nmap"
+dependency "john"
 
 # This depends on extra system libraries on OS X
 whitelist_file "#{install_dir}//framework/data/isight.bundle"

--- a/config/software/nmap.rb
+++ b/config/software/nmap.rb
@@ -1,0 +1,15 @@
+name "nmap"
+default_version "6.47"
+
+version("6.47") { source md5: "edfe81f6763223c0a29bfa15a8526e2a" }
+
+source url: "https://nmap.org/dist/nmap-6.47.tar.bz2"
+
+relative_path "nmap-#{version}"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  command "./configure --prefix=#{install_dir}/embedded", env: env
+  make env: env
+  make "install", env: env
+end


### PR DESCRIPTION
Builders for nmap and john the ripper.

Please run ```bin/omnibus build metasploit-framework```, and give them a try. The files will be at /opt/metasploit-framework/embedded/bin