### PR TITLE
Fix readlink -f not existing on OS X

### DIFF
--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -2,7 +2,7 @@
 #set -e
 #set -x
 
-BASE=/opt/metasploit-framework
+BASE=<%= install_dir %>
 EMBEDDED=$BASE/embedded
 BIN=$EMBEDDED/bin
 FRAMEWORK=$EMBEDDED/framework

--- a/config/templates/metasploit-framework/msfwrapper.erb
+++ b/config/templates/metasploit-framework/msfwrapper.erb
@@ -8,9 +8,9 @@ if [ $cmd = "msfwrapper" ]; then
 fi
 
 CWD=`pwd`
-SCRIPT=`readlink -f $0`
-cd `dirname $SCRIPT`
-SCRIPTDIR=`pwd -P`
+SCRIPTDIR=<%= install_dir %>/bin
+SCRIPT=$SCRIPTDIR/msfwrapper
+cd $SCRIPTDIR
 EMBEDDED=$SCRIPTDIR/../embedded
 BIN=$EMBEDDED/bin
 FRAMEWORK=$EMBEDDED/framework


### PR DESCRIPTION
Also refactor a bit of the ```pwd``` code and use ```install_dir```.

MSF-203