### PR TITLE
Fixup msfdb to auto-start on init if the database is not started.

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -32,7 +32,7 @@ start_db() {
     if $PG_CTL -o "-p $DBPORT" -D $DB status > /dev/null; then
       echo "Database already started at $DB"
     else
-      echo Starting Postgresql
+      echo "Starting database at $DB"
       $PG_CTL -o "-p $DBPORT" -D $DB -l $DB/log start > /dev/null
       sleep 2
     fi
@@ -51,7 +51,8 @@ stop_db() {
 
 init_db() {
   if [ -e $DB ]; then
-    echo "A database appears to exist at $DB, skipping initialization"
+    echo "Found a database at $DB, checking to see if it is started"
+    start_db
     return
   fi
 
@@ -87,7 +88,7 @@ EOF
 
   chmod 640 $DBCONF
 
-  echo Creating database at $DB
+  echo "Creating database at $DB"
   mkdir $DB
   $BIN/initdb --auth-host=trust --auth-local=trust -E UTF8 $DB > /dev/null
   echo "host    \"msf\"      \"${MSF_USER}\"      127.0.0.1/32           md5" >> $DB/pg_hba.conf


### PR DESCRIPTION
This makes it work more smoothly if you run msfconsole but the database is not started, e.g.:

```
:~/projects/metasploit-omnibus$ msfdb stop
:~/projects/metasploit-omnibus$ msfconsole -q
Found a database at /Users/bcook/.msf4/db, checking to see if it is started
Starting database at /Users/bcook/.msf4/db
msf >
```

MSF-206