### PR TITLE
update-alternatives should point directly to the bin now

### DIFF
--- a/package-scripts/metasploit-framework/postinst
+++ b/package-scripts/metasploit-framework/postinst
@@ -4,15 +4,11 @@
 # after package is installed.
 #
 
-echo "Thank you for installing Metasploit Framework!"
-
-BINS="msfbinscan msfconsole msfd msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfvenom"
+BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom"
 
 if [ -x /usr/sbin/update-alternatives -o -x /usr/bin/update-alternatives ] ; then
 	for BIN in $BINS; do
-		update-alternatives --install /usr/bin/$BIN $BIN /opt/metasploit-framework/bin/msfwrapper 100
-		update-alternatives --install /usr/bin/msfdb msfdb /opt/metasploit-framework/bin/msfdb 100
-		update-alternatives --install /usr/bin/msfupdate msfupdate /opt/metasploit-framework/bin/msfupdate 100
+		update-alternatives --install /usr/bin/$BIN $BIN /opt/metasploit-framework/bin/$BIN 100
 	done
 	echo "Run msfconsole to get started"
 else

--- a/package-scripts/metasploit-framework/prerm
+++ b/package-scripts/metasploit-framework/prerm
@@ -4,13 +4,11 @@
 # prior to installing package.
 #
 
-BINS="msfbinscan msfconsole msfd msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfvenom"
+BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom"
 
 if [ -x /usr/sbin/update-alternatives ] ; then
 	for BIN in $BINS; do
-		update-alternatives --remove $BIN /opt/metasploit-framework/bin/msfwrapper
-		update-alternatives --remove msfdb /opt/metasploit-framework/bin/msfdb
-		update-alternatives --remove msfupdate /opt/metasploit-framework/bin/msfupdate
+		update-alternatives --remove $BIN /opt/metasploit-framework/bin/$BIN
 	done
 fi
 


### PR DESCRIPTION
We don't render an msfwrapper directly anymore, so update-alternatives needs to be adjusted to match. This also removes special cases for msfdb / msfupdate and the duplicate invocations for those in the install loop. Minor aside, it also removes the default 'Thank you' message from omnibus, since no other package really does that.