### PR TITLE
add missing quote passing arguments to the underlying command

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -93,13 +93,10 @@ fi
 #    cmd="$cmd -L"
 #fi
 
-(
- cd $FRAMEWORK
- unset GEM_HOME
- unset GEM_PATH
- unset GEM_ROOT
- unset RUBY_ENGINE
- unset RUBY_ROOT
- PATH=$BIN:$SCRIPTDIR:$PATH
- $BIN/bundle exec $BIN/ruby ./$cmd "$*"
-)
+unset GEM_HOME
+unset GEM_PATH
+unset GEM_ROOT
+unset RUBY_ENGINE
+unset RUBY_ROOT
+PATH=$BIN:$SCRIPTDIR:$PATH
+$BIN/ruby $FRAMEWORK/$cmd "$*"

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -101,5 +101,5 @@ fi
  unset RUBY_ENGINE
  unset RUBY_ROOT
  PATH=$BIN:$SCRIPTDIR:$PATH
- $BIN/bundle exec $BIN/ruby ./$cmd $*
+ $BIN/bundle exec $BIN/ruby ./$cmd "$*"
 )


### PR DESCRIPTION
This fixes something like ```msfconsole -qx 'use exploit/multi-handler'``` to do the right thing, without losing the quotes passing to the underlying command.

# Verification steps

- [x]  ```msfconsole -qx 'use exploit/multi-handler'``` prints a prompt for multi-handler, not help text for the 'use' command

MSF-241