### PR TITLE
find the date of the script wrapper, not the symlinked command

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -78,7 +78,7 @@ init() {
   start_db
 }
 
-if [ -n "`find $0 -mmin +20160`" ]; then
+if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
 	echo "This copy of metasploit-framework is more than two weeks old."
 	echo " Consider running 'msfupdate' to update to the latest version."
 fi


### PR DESCRIPTION
This prevents false-positives when checking the date of the script to suggest if the user should run 'msfupdate' or not.