### PR TITLE
teach msfdb how to detect a corrupt database and suggest fixes

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -36,7 +36,7 @@ start_db() {
       $PG_CTL -o "-p $DBPORT" -D $DB -l $DB/log start > /dev/null
       sleep 2
       $BIN/pg_ctl -D $DB status > /dev/null
-      if [ $? != 0 ]; then
+      if [ $? -ne 0 ]; then
         echo -n "The database failed to start: "
         tail -n 1 $DB/log
         while true; do

--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -35,6 +35,19 @@ start_db() {
       echo "Starting database at $DB"
       $PG_CTL -o "-p $DBPORT" -D $DB -l $DB/log start > /dev/null
       sleep 2
+      $BIN/pg_ctl -D $DB status > /dev/null
+      if [ $? != 0 ]; then
+        echo -n "The database failed to start: "
+        tail -n 1 $DB/log
+        while true; do
+          read -p "If your database is corrupt, would you to reinitialize it? " yn
+          case $yn in
+            [Yy]* ) reinit_db; break;;
+            [Nn]* ) break;;
+                * ) echo "Please answer yes or no.";;
+          esac
+        done
+      fi
     fi
   else
     echo "No database found at $DB, not starting"


### PR DESCRIPTION
Sometimes a user can have a database in a bad state. We should check this condition on start, display the log, and suggest a fix:

```
vagrant@vagrant-ubuntu-trusty-64:~$ msfconsole
Found a database at /home/vagrant/.msf4/db, checking to see if it is started
Starting database at /home/vagrant/.msf4/db
The database failed to start:FATAL:  incorrect checksum in control file
If your database is corrupt, would you to reinitialize it? yes
Deleting all data at /home/vagrant/.msf4/db
Database is no longer running at /home/vagrant/.msf4/db
Creating database at /home/vagrant/.msf4/db
Starting database at /home/vagrant/.msf4/db
Creating database users
Creating initial database schema
[*] The initial module cache will be built in the background, this can take 2-5 minutes...
```