### PR TITLE
Add RPM repository build and install support

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 print_pgp_key() {
-	cat <<-EOF
+  cat <<-EOF
 -----BEGIN PGP PUBLIC KEY BLOCK-----
 Version: GnuPG v1
 
@@ -58,28 +58,28 @@ EOF
 }
 
 install_deb() {
-	LIST_FILE=/etc/apt/sources.list.d/metasploit-framework.list
-	if [ ! -f $LIST_FILE ]; then
-		echo -n "Adding metasploit-framework to your repository list.."
-		echo "deb $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
-		print_pgp_key | apt-key add -
-	fi
-	echo -n "Updating package cache.."
-	apt-get update > /dev/null
-	echo "OK"
-	echo "Checking for and installing update.."
-	apt-get install metasploit-framework
+  LIST_FILE=/etc/apt/sources.list.d/metasploit-framework.list
+  if [ ! -f $LIST_FILE ]; then
+    echo -n "Adding metasploit-framework to your repository list.."
+    echo "deb $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
+    print_pgp_key | apt-key add -
+  fi
+  echo -n "Updating package cache.."
+  apt-get update > /dev/null
+  echo "OK"
+  echo "Checking for and installing update.."
+  apt-get install metasploit-framework
 
 }
 
 install_rpm() {
-	echo "Checking for and installing update.."
-	REPO_FILE=/etc/yum.repos.d/metasploit-framework.repo
-	GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit
-	if [ ! -f $REPO_FILE ]; then
-		echo -n "Adding metasploit-framework to your repository list.."
+  echo "Checking for and installing update.."
+  REPO_FILE=/etc/yum.repos.d/metasploit-framework.repo
+  GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit
+  if [ ! -f $REPO_FILE ]; then
+    echo -n "Adding metasploit-framework to your repository list.."
 
-        sh -c "cat - > /etc/yum.repos.d/metasploit-framework.repo <<EOF
+    sh -c "cat - > /etc/yum.repos.d/metasploit-framework.repo <<EOF
 [metasploit]
 name=Metasploit
 baseurl=$DOWNLOAD_URI/rpm
@@ -87,9 +87,9 @@ gpgcheck=1
 gpgkey=file://$GPG_KEY_FILE
 enabled=1
 EOF"
-        print_pgp_key > ${GPG_KEY_FILE}
-	fi
-	yum install -y metasploit-framework
+    print_pgp_key > ${GPG_KEY_FILE}
+  fi
+  yum install -y metasploit-framework
 }
 
 DOWNLOAD_URI=http://downloads.metasploit.com/data/releases/metasploit-framework
@@ -97,37 +97,37 @@ PKGTYPE=unknown
 ID=`id -u`
 
 if [ -f /etc/redhat-release ] ; then
-    PKGTYPE=rpm
+  PKGTYPE=rpm
 else
-    uname -sv | grep 'Darwin' > /dev/null
-    if [ $? -eq 0 ]; then
-        PKGTYPE=pkg
-    else
-        PKGTYPE=deb
-    fi
+  uname -sv | grep 'Darwin' > /dev/null
+  if [ $? -eq 0 ]; then
+    PKGTYPE=pkg
+  else
+    PKGTYPE=deb
+  fi
 fi
 
 if [ $PKGTYPE != "pkg" -a "$ID" != "0" ]; then
-    SUDO=`which sudo`
-    if [ $? -ne 0 ]; then
-        echo "This script must be executed as the 'root' user or with sudo"
-        exit 1
-    else
-		echo "Switching to root user to update the package"
-        sudo -E $0 $@
-        exit 0
-    fi
+  SUDO=`which sudo`
+  if [ $? -ne 0 ]; then
+    echo "This script must be executed as the 'root' user or with sudo"
+    exit 1
+  else
+    echo "Switching to root user to update the package"
+    sudo -E $0 $@
+    exit 0
+  fi
 fi
 
 case $PKGTYPE in
-    deb)
-		install_deb
-        ;;
-    rpm)
-		install_rpm
-        ;;
-    *)
-        #installer -verboseR -pkg "metasploit-framework*.pkg" -target /
-        echo "Automatic updates are not yet supported on OS X."
-        echo "Please download and install the latest package manually."
+  deb)
+    install_deb
+    ;;
+  rpm)
+    install_rpm
+    ;;
+  *)
+    #installer -verboseR -pkg "metasploit-framework*.pkg" -target /
+    echo "Automatic updates are not yet supported on OS X."
+    echo "Please download and install the latest package manually."
 esac

--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -74,7 +74,22 @@ install_deb() {
 
 install_rpm() {
 	echo "Checking for and installing update.."
-	yum install metasploit-framework
+	REPO_FILE=/etc/yum.repos.d/metasploit-framework.repo
+	GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit
+	if [ ! -f $REPO_FILE ]; then
+		echo -n "Adding metasploit-framework to your repository list.."
+
+        sh -c "cat - > /etc/yum.repos.d/metasploit-framework.repo <<EOF
+[metasploit]
+name=Metasploit
+baseurl=$DOWNLOAD_URI/rpm
+gpgcheck=1
+gpgkey=file://$GPG_KEY_FILE
+enabled=1
+EOF"
+        print_pgp_key > ${GPG_KEY_FILE}
+	fi
+	yum install -y metasploit-framework
 }
 
 DOWNLOAD_URI=http://downloads.metasploit.com/data/releases/metasploit-framework

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -37,7 +37,7 @@ check_db() {
 }
 
 check_path() {
-  if [ "`which msfconsole`" = "" ]; then
+  if [ ! hash $cmd 2>/dev/null ]; then
     while true; do
       read -p "Would you like to add $cmd and other programs to your default PATH? " yn
         case $yn in

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -61,26 +61,26 @@ start_db() {
 
 init() {
   if [ ! -e $LOCALCONF/initial_setup_complete ]; then
-      mkdir -p $LOCALCONF
-      echo
-      echo " ** Welcome to Metasploit Framework Initial Setup **"
-      echo "    Please answer a few questions to get started."
-      echo
-      check_path
-      echo
-      check_db
-      echo
-      echo " ** Metasploit Framework Initial Setup Complete **"
-      echo
-      touch $LOCALCONF/initial_setup_complete
+    mkdir -p $LOCALCONF
+    echo
+    echo " ** Welcome to Metasploit Framework Initial Setup **"
+    echo "    Please answer a few questions to get started."
+    echo
+    check_path
+    echo
+    check_db
+    echo
+    echo " ** Metasploit Framework Initial Setup Complete **"
+    echo
+    touch $LOCALCONF/initial_setup_complete
   fi
 
   start_db
 }
 
 if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
-	echo "This copy of metasploit-framework is more than two weeks old."
-	echo " Consider running 'msfupdate' to update to the latest version."
+  echo "This copy of metasploit-framework is more than two weeks old."
+  echo " Consider running 'msfupdate' to update to the latest version."
 fi
 
 # Skip initialization if we're root

--- a/docker/omnibus-centos6/Dockerfile
+++ b/docker/omnibus-centos6/Dockerfile
@@ -30,9 +30,10 @@ RUN yum install -y \
     rpm-build \
     fakeroot \
     git \
-    ccache
-RUN yum clean all
-
+    ccache \
+    createrepo \
+    expect \
+	&& yum clean all
 
 RUN curl -L https://www.opscode.com/chef/install.sh | bash
 RUN git config --global user.email "packager@myco" && \
@@ -49,13 +50,25 @@ RUN rm -fr metasploit-omnibus
 
 ENV JENKINS_HOME /var/jenkins_home
 RUN useradd -d "$JENKINS_HOME" -u 1001 -m -s /bin/sh jenkins
-RUN cp ~/.gitconfig "$JENKINS_HOME"
-RUN chown -R jenkins "$JENKINS_HOME"
 
 RUN mkdir -p /var/cache/omnibus
 RUN mkdir -p /opt/metasploit-framework
 RUN chown jenkins /var/cache/omnibus
 RUN chown jenkins /opt/metasploit-framework
 RUN chown -R jenkins /opt/chef/embedded/lib/ruby/gems
+
+RUN echo "#!/usr/bin/expect -f" > /usr/bin/signrpm && \
+	echo "spawn rpm --addsign {*}\$argv" >> /usr/bin/signrpm && \
+	echo "expect -exact \"Enter pass phrase: \"" >> /usr/bin/signrpm && \
+	echo "send -- \"\r\"" >> /usr/bin/signrpm && \
+	echo "expect eof" >> /usr/bin/signrpm
+RUN chmod 755 /usr/bin/signrpm
+
+RUN cp ~/.gitconfig "$JENKINS_HOME"
+RUN echo "%_signature gpg" > "$JENKINS_HOME/.rpmmacros" && \
+	echo "%_gpg_name 35AF4DDB" >> "$JENKINS_HOME/.rpmmacros" && \
+	echo "%__gpg_check_password_cmd /bin/true" >> "$JENKINS_HOME/.rpmmacros" && \
+	echo "%__gpg_sign_cmd %{__gpg} gpg --batch --no-verbose --no-armor --use-agent --no-secmem-warning -u \"%{_gpg_name}\" -sbo %{__signature_filename} %{__plaintext_filename}" >> "$JENKINS_HOME/.rpmmacros"
+RUN chown -R jenkins "$JENKINS_HOME"
 
 ENV PATH /opt/chef/embedded/bin:$PATH


### PR DESCRIPTION
These changes add support for installing metasploit-framework packages on Fedora / Centos. Simply running the msfupdate.erb script will install the latest build.
