### PR TITLE
don't use 'which' in msfupdate

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -108,7 +108,7 @@ else
 fi
 
 if [ $PKGTYPE != "pkg" -a "$ID" != "0" ]; then
-  SUDO=`which sudo`
+  hash sudo 2>/dev/null
   if [ $? -ne 0 ]; then
     echo "This script must be executed as the 'root' user or with sudo"
     exit 1


### PR DESCRIPTION
Which cannot be relied upon in a base system, e.g. centos, so let's not assume it exists.