### PR TITLE
add msfupdate and msfremove for windows

### DIFF
--- a/config/software/metasploit-framework-wrappers-windows.rb
+++ b/config/software/metasploit-framework-wrappers-windows.rb
@@ -12,10 +12,25 @@ build do
       mode: 0755,
       vars: { install_dir: install_dir }
 
-#  erb source: 'msfupdate.bat.erb',
-#      dest: "#{install_dir}/bin/msfupdate",
-#      mode: 0755,
-#      vars: { install_dir: install_dir }
+  erb source: 'msfremove.ps1.erb',
+      dest: "#{install_dir}/bin/msfremove.ps1",
+      mode: 0755,
+      vars: { install_dir: install_dir }
+
+  erb source: 'msfremove.bat.erb',
+      dest: "#{install_dir}/bin/msfremove.bat",
+      mode: 0755,
+      vars: { install_dir: install_dir }
+
+  erb source: 'msfupdate.ps1.erb',
+      dest: "#{install_dir}/bin/msfupdate.ps1",
+      mode: 0755,
+      vars: { install_dir: install_dir }
+
+  erb source: 'msfupdate.bat.erb',
+      dest: "#{install_dir}/bin/msfupdate.bat",
+      mode: 0755,
+      vars: { install_dir: install_dir }
 
   metasploit_bins = [
         'msfbinscan',

--- a/config/templates/metasploit-framework-wrappers-windows/msfremove.bat.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfremove.bat.erb
@@ -1,0 +1,3 @@
+@echo off
+set SCRIPTDIR=%~dp0
+powershell -ExecutionPolicy ByPass -File %SCRIPTDIR%\msfupdate.ps1

--- a/config/templates/metasploit-framework-wrappers-windows/msfremove.ps1.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfremove.ps1.erb
@@ -1,0 +1,17 @@
+$filterSpec = "Metasploit-framework"
+
+$hives = @("HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall", "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall")
+$hives |% {
+  $keys = gci $_ -Recurse
+  $subkeys = $keys |% {
+    $displayName = [string]$_.GetValue("DisplayName")
+    $uninstallString = ([string]$_.GetValue("UninstallString")).ToLower().Replace("/i", "").Replace("msiexec.exe", "")
+
+    if ($displayName.StartsWith($filterSpec)) {
+      msfdb stop
+      Write-Host "Uninstalling product: $displayName"
+      Write-Host "$uninstallString"
+      start-process "msiexec.exe" -arg "/X $uninstallString /qn" -Wait
+    }
+  }
+}

--- a/config/templates/metasploit-framework-wrappers-windows/msfupdate.bat.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfupdate.bat.erb
@@ -1,0 +1,3 @@
+@echo off
+set SCRIPTDIR=%~dp0
+powershell -ExecutionPolicy ByPass -File %SCRIPTDIR%\msfupdate.ps1

--- a/config/templates/metasploit-framework-wrappers-windows/msfupdate.ps1.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfupdate.ps1.erb
@@ -1,0 +1,11 @@
+$source = "http://windows.metasploit.com/metasploitframework-latest.msi"
+$destination = "$env:userprofile\Downloads\metasploitframework-latest.msi"
+
+Write-Output "Downloading latest Metasploit Framework"
+Import-Module BitsTransfer
+Start-BitsTransfer -Source $source -Destination $destination
+
+Write-Output "Updating Metasploit Framework"
+Start-Process "$env:userprofile\Downloads\metasploitframework-latest.msi" /qn -Wait
+
+Write-Output "Update Complete"


### PR DESCRIPTION
This adds a powershell script for downloading updated packages. The wrapper batch file is needed to bypass default policies that do not allow running powershell scripts.