### PR TITLE
bump nokogiri to 1.6.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,3 @@ DEPENDENCIES
   omnibus!
   test-kitchen (~> 1.2)
   vagrant-wrapper (~> 2.0.2)
-
-BUNDLED WITH
-   1.10.6

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -15,7 +15,7 @@
 #
 
 name "nokogiri"
-default_version "1.6.6.2"
+default_version "1.6.7"
 
 if windows?
   dependency "ruby-windows"


### PR DESCRIPTION
- [x] Do a test build of this branch

If it builds properly, it should be good to go.

Chose not to bump libxml to 2.9.3 because doing so resulted in the following error:
/Users/gmikeska/.rvm/gems/ruby-2.1.6@pro/bundler/gems/omnibus-08c4b8e72a61/lib/omnibus/digestable.rb:104:in `const_get': wrong constant name [:SHA512, :SHA256, :SHA1, :MD5] (NameError)

libxml2 v2.9.2 satisfies requirements anyway