### PR TITLE
update the msfupdate command on windows to raise privilege as needed

### DIFF
--- a/config/templates/metasploit-framework-wrappers-windows/msfupdate.ps1.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfupdate.ps1.erb
@@ -6,6 +6,17 @@ Import-Module BitsTransfer
 Start-BitsTransfer -Source $source -Destination $destination
 
 Write-Output "Updating Metasploit Framework"
-Start-Process "$env:userprofile\Downloads\metasploitframework-latest.msi" /qn -Wait
+$arguments =
+@(
+	"/I `"$env:userprofile\Downloads\metasploitframework-latest.msi`"",
+	"/QB",
+	"/L*V `"$ENV:TEMP\msfupdate.log`""
+)
 
-Write-Output "Update Complete"
+$p = Start-Process -FilePath "msiexec" -ArgumentList $arguments -Wait -PassThru
+if($p.ExitCode -ne 0)
+{
+	Write-Output "Metasploit update failed, error code: $($p.ExitCode)"
+} else {
+	Write-Output "Update Complete"
+}


### PR DESCRIPTION
This fixes #29 by adding a log file during install (useful for debugging) and by switching to the 'basic' install screen, which enables a UAC prompt as-needed.

# Verification
 - [x] install an older version of the metasploit framework windows package from windows.metasploit.com
 - [x] copy the contents of this file over the msfupdate.ps1 file under c:\metasploit\bin\
 - [x] run msfupdate.bat, ensure that the the package prompts for user permissions to install and works as expected (the version bumps)