### PR TITLE
Omnibus changes to support rex bin gemification (PR #7208).

### DIFF
--- a/config/templates/metasploit-framework-wrappers-windows/msfwrapper.bat.erb
+++ b/config/templates/metasploit-framework-wrappers-windows/msfwrapper.bat.erb
@@ -15,6 +15,10 @@ set RUBY_ENGINE=
 set RUBY_ROOT=
 set PATH=%BIN%;%PATH%
 
-ruby %FRAMEWORK%\%CMD% %*
+if exist %FRAMEWORK%\%CMD% (
+  ruby %FRAMEWORK%\%CMD% %*
+) else (
+  ruby %BIN%\%CMD% %*
+)
 
 endlocal

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -103,4 +103,8 @@ unset GEM_ROOT
 unset RUBY_ENGINE
 unset RUBY_ROOT
 PATH=$BIN:$SCRIPTDIR:$PATH
-$BIN/ruby $FRAMEWORK/$cmd "$@"
+if [ -e $FRAMEWORK/$cmd ]; then
+  $BIN/ruby $FRAMEWORK/$cmd "$@"
+else
+  $BIN/ruby $BIN/$cmd "$@"
+fi


### PR DESCRIPTION
I've verified that omnibus-generated packages for both Linux and Windows "do the right thing" with the new rex-bin_tools gem.

See MS-2002 and MS-1691.

# Validation steps (shorter path; do the following for both Linux and Windows)

 - [ ] assuming you can trust @pbarry-r7, go get the packages he's built (via omnibus) which contain the changes in this PR as well as @dmaloney-r7's changes in [PR #7208](https://github.com/rapid7/metasploit-framework/pull/7208)
 - [ ] install the package
 - [ ] **Verify** msfbinscan, msfelfscan, msfmachscan, and msfpescan scripts now appear in the `<msf install dir>/bin directory` (this shows we're using the new gem)
 - [ ] **Verify** you can run these tools on the command line and get usage statements for each of them (this verifies the omnibus install correctly finds these tools even though they are no longer part of msf itself)

# Validation steps (longer path; do the following for both Linux and Windows)

 - [ ] setup an [omnibus build env](https://github.com/rapid7/metasploit-omnibus/blob/master/README.md)
 - [ ] edit line 3 of the config/software/metasploit-framework.rb file to point to the rex-bin-tools msf branch (`default_version "rex-bin-tools"`)
 - [ ] build the package
 - [ ] install the package
 - [ ] **Verify** msfbinscan, msfelfscan, msfmachscan, and msfpescan scripts now appear in the `<msf install dir>/bin directory` (this shows we're using the new gem)
 - [ ] **Verify** you can run these tools on the command line and get usage statements for each of them (this verifies the omnibus install correctly finds these tools even though they are no longer part of msf itself)