### PR TITLE
don't pass the full command to '-e', only the binary path

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -83,9 +83,10 @@ if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
 fi
 
 # If we are on an updated Kali system, try to use the system database
+db_args=""
 if [ -e /usr/share/metasploit-framework/config/database.yml \
      -a ! -e $LOCALCONF/database.yml ]; then
-  cmd="$cmd -y /usr/share/metasploit-framework/config/database.yml"
+  db_args="-y /usr/share/metasploit-framework/config/database.yml"
 else # Skip initialization if we're root
   if [ "`id -u`" -gt 0 ]; then
     init
@@ -103,8 +104,8 @@ unset GEM_ROOT
 unset RUBY_ENGINE
 unset RUBY_ROOT
 PATH=$BIN:$SCRIPTDIR:$PATH
-if [ -e $FRAMEWORK/$cmd ]; then
-  $BIN/ruby $FRAMEWORK/$cmd "$@"
+if [ -e "$FRAMEWORK/$cmd" ]; then
+  $BIN/ruby $FRAMEWORK/$cmd $db_args "$@"
 else
-  $BIN/ruby $BIN/$cmd "$@"
+  $BIN/ruby $BIN/$cmd $db_args "$@"
 fi


### PR DESCRIPTION
This fixes an issue specific to the latest version of Kali rolling release, where the 'dash' command has become more strict in what it is passed, and we try to fall back to using the Kali system-wide database for metasploit. Thanks to @mubix for reporting.