### PR TITLE
workaround busted bcrypt on windows by specifying the ruby platform

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -52,6 +52,9 @@ build do
       mode: 0755,
       vars: { install_dir: install_dir }
 
+  # Workaround broken Ruby 2.3 support for bcrypt on Windows
+  # https://github.com/codahale/bcrypt-ruby/issues/139
+  bundle "config build.bcrypt --platform=ruby"
   bundle "install"
 
   if windows?


### PR DESCRIPTION
This fixes #42 by applying the workaround suggested here: https://github.com/codahale/bcrypt-ruby/issues/139#issuecomment-235925654

Unfortunately upstream has not really paid attention to this, and we'll likely hit the same issue with 2.4 later on.