### PR TITLE
move birthday check to only affect msfconsole, redirect to stderr

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -91,10 +91,6 @@ fi
 if [ $cmd = "msfconsole" ]; then
 # Uncomment to enable libedit support
 # cmd="$cmd -L"
-  if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
-    (>&2 echo "This copy of metasploit-framework is more than two weeks old.")
-    (>&2 echo " Consider running 'msfupdate' to update to the latest version.")
-  fi
 fi
 
 unset GEM_HOME

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -77,11 +77,6 @@ init() {
   start_db
 }
 
-if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
-  echo "This copy of metasploit-framework is more than two weeks old."
-  echo " Consider running 'msfupdate' to update to the latest version."
-fi
-
 # If we are on an updated Kali system, try to use the system database
 db_args=""
 if [ -e /usr/share/metasploit-framework/config/database.yml \
@@ -93,10 +88,14 @@ else # Skip initialization if we're root
   fi
 fi
 
+if [ $cmd = "msfconsole" ]; then
 # Uncomment to enable libedit support
-#if [ $cmd = "msfconsole" ]; then
-#    cmd="$cmd -L"
-#fi
+# cmd="$cmd -L"
+  if [ -n "`find $FRAMEWORK/$cmd -mmin +20160`" ]; then
+    (>&2 echo "This copy of metasploit-framework is more than two weeks old.")
+    (>&2 echo " Consider running 'msfupdate' to update to the latest version.")
+  fi
+fi
 
 unset GEM_HOME
 unset GEM_PATH


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/7925

```
$ msfconsole -qx 'quit'
This copy of metasploit-framework is more than two weeks old.
 Consider running 'msfupdate' to update to the latest version.

$ msfvenom -p linux/x86/mettle/reverse_tcp -f elf > test.elf
No platform was selected, choosing Msf::Module::Platform::Linux from the payload
No Arch selected, selecting Arch: x86 from the payload
No encoder or badchars specified, outputting raw payload
Payload size: 71 bytes
Final size of elf file: 155 bytes
Saved as: test.elf

$ strings test.elf
SCSj
jfXPQW
```