### PR TITLE
Update postgresql, include Kali linux specific fallback for msfdb

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -52,6 +52,13 @@ build do
       mode: 0755,
       vars: { install_dir: install_dir }
 
+  unless windows?
+    erb source: 'msfdb-kali.erb',
+        dest: "#{install_dir}/embedded/framework/msfdb-kali",
+        mode: 0755,
+        vars: { install_dir: install_dir }
+  end
+
   env = with_standard_compiler_flags(with_embedded_path)
   bundle "install", env: env
 

--- a/config/software/postgresql-windows.rb
+++ b/config/software/postgresql-windows.rb
@@ -15,7 +15,11 @@
 #
 
 name "postgresql-windows"
-default_version "9.6.1"
+default_version "9.6.2"
+
+version "9.6.2" do
+  source sha256: "a4c1f9c4e4938abee245926bbc950a5d01fc3776187044aec2fb1698120f447a"
+end
 
 version "9.6.1" do
   source sha256: "16a5b97579587bf6c6ab98788b0c95e55398e87a75b990089522d4837b2da0f4"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.6.1"
+default_version "9.6.2"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -27,6 +27,10 @@ dependency "libedit"
 dependency "libuuid" unless mac_os_x?
 dependency "ncurses"
 dependency "config_guess"
+
+version "9.6.2" do
+  source sha256: "0187b5184be1c09034e74e44761505e52357248451b0c854dddec6c231fe50c9"
+end
 
 version "9.6.1" do
   source sha256: "e5101e0a49141fc12a7018c6dad594694d3a3325f5ab71e93e0e51bd94e51fcd"

--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -10,4 +10,11 @@ unset GEM_ROOT
 unset RUBY_ENGINE
 unset RUBY_ROOT
 
+if [ -e /etc/os-release -a $(id -u) -eq 0 ]; then
+  if grep -q kali /etc/os-release; then
+    echo "Metasploit running on Kali Linux as root, using system database"
+	exec $INSTALL_DIR/embedded/framework/msfdb-kali "$@"
+  fi
+fi
+
 ruby "$INSTALL_DIR/embedded/framework/msfdb" "$@"

--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -13,7 +13,10 @@ unset RUBY_ROOT
 if [ -e /etc/os-release -a $(id -u) -eq 0 ]; then
   if grep -q kali /etc/os-release; then
     echo "Metasploit running on Kali Linux as root, using system database"
-	exec $INSTALL_DIR/embedded/framework/msfdb-kali "$@"
+    if [ ! -e /usr/share/metasploit-framework/config ]; then
+      mkdir -p /usr/share/metasploit-framework/config
+    fi
+    exec $INSTALL_DIR/embedded/framework/msfdb-kali "$@"
   fi
 fi
 

--- a/config/templates/metasploit-framework/msfdb-kali.erb
+++ b/config/templates/metasploit-framework/msfdb-kali.erb
@@ -1,0 +1,153 @@
+#!/bin/sh
+
+METASPLOIT_BASEDIR=/usr/share/metasploit-framework
+
+DB_CONF=$METASPLOIT_BASEDIR/config/database.yml
+DB_NAME=msf
+DB_USER=msf
+DB_PORT=5432
+PG_SERVICE=postgresql
+
+pw_gen() {
+    openssl rand -base64 32
+}
+
+pg_cmd() {
+    su - postgres -c "$*"
+}
+
+start_db() {
+    if ! service $PG_SERVICE status >/dev/null; then
+	service $PG_SERVICE start
+    fi
+}
+
+stop_db() {
+    if service $PG_SERVICE status >/dev/null; then
+	service $PG_SERVICE stop
+    fi
+}
+
+db_exists() {
+    if pg_cmd "psql -lqt" | cut -d \| -f 1 | grep -qw $1; then
+	return 0
+    fi
+    return 1
+}
+
+user_exists() {
+    if echo "SELECT usename FROM pg_user;" | pg_cmd "psql -qt postgres" | grep -qw $1; then
+	return 0
+    fi
+    return 1
+}
+
+init_db() {
+    start_db
+    if [ -e $DB_CONF ]; then
+	echo "A database appears to be already configured, skipping initialization" 
+	return
+    fi
+    DB_PASS=$(pw_gen)
+    if user_exists $DB_USER; then
+	echo "Resetting password of database user '$DB_USER'"
+	printf "ALTER ROLE $DB_USER WITH PASSWORD '$DB_PASS';\n" | pg_cmd psql postgres >/dev/null
+    else
+	echo "Creating database user '$DB_USER'"
+	printf "%s\n%s\n" "$DB_PASS" "$DB_PASS" | pg_cmd createuser -S -D -R -P $DB_USER >/dev/null
+    fi
+    echo "Creating databases '$DB_NAME' and '${DB_NAME}_test'"
+    if ! db_exists $DB_NAME; then
+	pg_cmd createdb $DB_NAME -O $DB_USER -T template0 -E UTF-8
+    fi
+    if ! db_exists ${DB_NAME}_test; then
+	pg_cmd createdb ${DB_NAME}_test -O $DB_USER -T template0 -E UTF-8
+    fi
+    echo "Creating configuration file in $DB_CONF"
+    cat > $DB_CONF <<-EOF
+development:
+  adapter: postgresql
+  database: $DB_NAME
+  username: $DB_USER
+  password: $DB_PASS
+  host: localhost
+  port: $DB_PORT
+  pool: 5
+  timeout: 5
+
+production:
+  adapter: postgresql
+  database: $DB_NAME
+  username: $DB_USER
+  password: $DB_PASS
+  host: localhost
+  port: $DB_PORT
+  pool: 5
+  timeout: 5
+
+test:
+  adapter: postgresql
+  database: ${DB_NAME}_test
+  username: $DB_USER
+  password: $DB_PASS
+  host: localhost
+  port: $DB_PORT
+  pool: 5
+  timeout: 5
+EOF
+    echo "Creating initial database schema"
+    cd $METASPLOIT_BASEDIR
+    bundle exec rake db:migrate >/dev/null
+}
+
+delete_db() {
+    start_db
+    if db_exists $DB_NAME; then
+	pg_cmd dropdb $DB_NAME
+    fi
+    if db_exists ${DB_NAME}_test; then
+	pg_cmd dropdb ${DB_NAME}_test
+    fi
+    if user_exists $DB_USER; then
+	pg_cmd dropuser $DB_USER
+    fi
+    rm -f $DB_CONF
+}
+
+reinit_db() {
+    delete_db
+    init_db
+}
+
+usage() {
+  PROG=`basename $0`
+  echo
+  echo "Manage a metasploit framework database"
+  echo
+  echo "  $PROG init    # initialize the database"
+  echo "  $PROG reinit  # delete and reinitialize the database"
+  echo "  $PROG delete  # delete database and stop using it"
+  echo "  $PROG start   # start the database"
+  echo "  $PROG stop    # stop the database"
+  echo
+  exit
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+fi
+
+if [ $(id -u) -ne 0 ]; then
+    echo "ERROR: $0: must be run as root"
+    exit 1
+fi
+
+case $1 in
+  init) init_db ;;
+  reinit) reinit_db ;;
+  delete) delete_db ;;
+  start) start_db ;;
+  stop) stop_db ;;
+  *) echo "Error: unrecognized action '${1}'"; usage ;;
+esac
+


### PR DESCRIPTION
This bumps the Omnibus installer to use the latest Postgresql packages.

It also includes a Kali linux-specific check for msfdb that falls back to using the system database if a user is running as root on that OS. Postgresql normally bails if you run as root, and the omnibus packages try to avoid any form of user management.