### PR TITLE
disable debug code

### DIFF
--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -31,8 +31,8 @@ def run_cmd(cmd)
 
   err = out = ""
   Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-    err = stderr.read
-    out = stdout.read
+#    err = stderr.read
+#    out = stdout.read
     exitstatus = wait_thr.value.exitstatus
   end
 


### PR DESCRIPTION
this hangs on Windows since there is no data on stderr and it blocks.
This fixes #53, the read from stderr was preventing `msfdb init` from getting past the 'starting' phase.