### PR TITLE
Msfdb init fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 cache: bundler
 before_install:
   - bundle install --binstubs
+  - sudo apt install fakeroot
   - sudo mkdir /var/cache/omnibus
   - sudo chown travis /var/cache/omnibus
   - sudo mkdir /opt/metasploit-framework

--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -3,6 +3,7 @@
 require 'fileutils'
 require 'open3'
 require 'securerandom'
+require 'yaml'
 
 DEBUG = false
 
@@ -101,6 +102,17 @@ def start_db
   if !Dir.exist?(@db)
     puts "No database found at #{@db}, not starting"
     return
+  end
+
+  if File.exist?(@dbconf)
+    config = YAML.load(File.read(@dbconf))
+    if config["production"] && config["production"]["port"]
+      port = config["production"]["port"]
+      if port != @dbport
+        puts "Using database port #{port}"
+        @dbport = port
+      end
+    end
   end
 
   while !started_db

--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -4,6 +4,8 @@ require 'fileutils'
 require 'open3'
 require 'securerandom'
 
+DEBUG = false
+
 # Bomb out if we're root
 if !Gem.win_platform? && Process.uid.zero?
   puts "Please run #{File.basename($0)} as a non-root user"
@@ -26,27 +28,35 @@ end
 @msftest_user = 'msftest'
 
 
-def run_cmd(cmd)
+def run_cmd(cmd, input = nil)
   exitstatus = 0
 
   err = out = ""
   Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thr|
-#    err = stderr.read
-#    out = stdout.read
+    stdin.puts(input) if input
+    if DEBUG
+      err = stderr.read
+      out = stdout.read
+    end
     exitstatus = wait_thr.value.exitstatus
   end
 
-#  if exitstatus != 0
-#    puts "'#{cmd}' returned #{exitstatus}"
-#    puts out
-#    puts err
-#  end
+  if exitstatus != 0
+    if DEBUG
+      puts "'#{cmd}' returned #{exitstatus}"
+      puts out
+      puts err
+    end
+  end
 
   exitstatus
 end
 
 def run_psql(cmd)
   run_cmd("#{@bin}/psql -p #{@dbport} -c \"#{cmd};\" postgres")
+  if DEBUG
+    $stderr.puts "#{@bin}/psql -p #{@dbport} -c \"#{cmd};\" postgres"
+  end
 end
 
 def pw_gen
@@ -129,9 +139,11 @@ def create_db
   Dir.mkdir(@db)
   run_cmd("#{@bin}/initdb --auth-host=trust --auth-local=trust -E UTF8 #{@db}")
 
-  File.open("#{@db}/pg_hba.conf", 'a') do |f|
+  File.open("#{@db}/pg_hba.conf", 'w') do |f|
     f.puts "host    \"msf\"      \"#{@msf_user}\"      127.0.0.1/32           md5"
     f.puts "host    \"msftest\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
+    f.puts "local   all             all                                       trust"
+    f.puts "host    \"template1\"   all                127.0.0.1/32           trust"
   end
 
   File.open("#{@db}/postgresql.conf", 'a') do |f|
@@ -179,8 +191,8 @@ development: &pgsql
   adapter: postgresql
   database: msf
   username: #{@msf_user}
-  password: #{@msf_pass}
-  host: localhost
+  password: #{msf_pass}
+  host: 127.0.0.1
   port: #{@dbport}
   pool: 200
   timeout: 5
@@ -205,10 +217,14 @@ EOF
   puts 'Creating database users'
   run_psql("create user #{@msf_user} with password '#{msf_pass}'")
   run_psql("create user #{@msftest_user} with password '#{msftest_pass}'")
-  run_psql("alter user msf createdb")
-  run_psql("alter user msftest createdb")
-  run_cmd("#{@bin}/createdb -p #{@dbport} -O #{@msf_user} -h localhost msf")
-  run_cmd("#{@bin}/createdb -p #{@dbport} -O #{@msftest_user} -h localhost msftest")
+  run_psql("alter role msf createdb")
+  run_psql("alter role msftest createdb")
+  run_psql("alter role #{@msf_user} with password '#{msf_pass}'")
+  run_psql("alter role #{@msftest_user} with password '#{msftest_pass}'")
+  run_cmd("#{@bin}/createdb -p #{@dbport} -O #{@msf_user} -h 127.0.0.1 -U msf -E UTF-8 -T template0 msf",
+    "#{msf_pass}\n#{msf_pass}\n")
+  run_cmd("#{@bin}/createdb -p #{@dbport} -O #{@msftest_user} -h 127.0.0.1 -U msftest -E UTF-8 -T template0 msftest",
+    "#{msftest_pass}\n#{msftest_pass}\n")
 
   puts 'Creating initial database schema'
   Dir.chdir(@framework) do
@@ -237,7 +253,7 @@ def delete_db
     puts "Deleting all data at #{@db}"
     stop_db
     FileUtils.rm_rf(@db)
-    if ask_yn("Delete datase configuration at #{@dbconf}?")
+    if File.exist?(@dbconf) && ask_yn("Delete database configuration at #{@dbconf}?")
       File.delete(@dbconf)
     end
   else


### PR DESCRIPTION
This fixes a few issues with msfdb init on newer platforms:

  1. Our default hba config and setup were targeting `localhost`, but newer OSes default localhost to IPv6, which caused the system to fallback to the default access (no password). This replaces the postgresql default hba with a new one, and now prefer connecting to 127.0.0.1
  2. The msf password variable was incorrect, which led to the wrong value being written to database.yml
  3. database.yml delete prompt fails if the file doesn't exist

This also fixes #52