### PR TITLE
disable building postgresql-prev (we're over the upgrade hump)

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -11,13 +11,11 @@ dependency "bundler"
 dependency "pcaprub"
 if windows?
   dependency "postgresql-windows"
-  dependency "postgresql-windows-prev"
 else
   dependency "liblzma"
   dependency "libxslt"
   dependency "ruby"
   dependency "postgresql"
-  dependency "postgresql-prev"
   dependency "sqlite"
 end
 

--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -164,6 +164,10 @@ def create_db
 end
 
 def upgrade_db
+  unless File.exist?(@prev_bin)
+    puts "An old version of postgresql is not available, run 'msfdb reinit'"
+    return false
+  end
   prev_db = "#{@db}.prev"
   FileUtils.rm_rf(prev_db)
   FileUtils.mv(@db, prev_db)


### PR DESCRIPTION
We include 2 complete copies of postgresql currently to help people upgrade from 9.4 to 9.6. That's been a few months, let's axe it and get the space back.