### PR TITLE
Ensure that ~/.msf4 dir (localconf) is created prior to init. Fixes #61

### DIFF
--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -207,6 +207,7 @@ def init_db
   msftest_pass = pw_gen
 
   # Write a default database config file
+  Dir.mkdir(@localconf) unless File.directory?(@localconf)
   File.open(@dbconf, 'w') do |f|
     f.puts <<EOF
 development: &pgsql


### PR DESCRIPTION
Fixes #61.  One way to reproduce this is with the following `Dockerfile`:

```
FROM ubuntu:16.04
RUN apt-get update
RUN apt-get -y install curl sudo
RUN useradd -m msf
RUN bash -c "echo 'msf ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers"
RUN bash -c "sudo -H -u msf bash -c 'curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall && chmod 755 /tmp/msfinstall && /tmp/msfinstall && msfdb init'"
```

Build:

```
$  docker build -t msf-docker -f Dockerfile .                                         
Sending build context to Docker daemon  2.584MB
Step 1/6 : FROM ubuntu:16.04
 ---> 0458a4468cbc
Step 2/6 : RUN apt-get update
 ---> Using cache
 ---> 43040fcb7ba4
Step 3/6 : RUN apt-get -y install curl sudo
 ---> Using cache
 ---> e40c9f453319
Step 4/6 : RUN useradd -m msf
 ---> Using cache
 ---> 9e2ca30299ba
Step 5/6 : RUN bash -c "echo 'msf ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers"
 ---> Using cache
 ---> c795d509d5a8
Step 6/6 : RUN bash -c "sudo -H -u msf bash -c 'curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall && chmod 755 /tmp/msfinstall && /tmp/msfinstall && msfdb init'" ---> Running in 388b97f40404
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  5394  100  5394    0     0  10526      0 --:--:-- --:--:-- --:--:-- 10514
Switching to root user to update the package
Adding metasploit-framework to your repository list..OK
Updating package cache..OK
Checking for and installing update..
Reading package lists...
Building dependency tree...
Reading state information...
The following NEW packages will be installed:
  metasploit-framework
0 upgraded, 1 newly installed, 0 to remove and 6 not upgraded.
Need to get 186 MB of archives.
After this operation, 431 MB of additional disk space will be used.
Get:1 http://downloads.metasploit.com/data/releases/metasploit-framework/apt lucid/main amd64 metasploit-framework amd64 4.16.37+20180207154505.git.2.6f2f0ed~1rapid7-1 [186 MB]
debconf: delaying package configuration, since apt-utils is not installed
Fetched 186 MB in 1min 47s (1733 kB/s)
Selecting previously unselected package metasploit-framework.
(Reading database ... 5338 files and directories currently installed.)
Preparing to unpack .../metasploit-framework_4.16.37+20180207154505.git.2.6f2f0ed~1rapid7-1_amd64.deb ...
Unpacking metasploit-framework (4.16.37+20180207154505.git.2.6f2f0ed~1rapid7-1) ...
Setting up metasploit-framework (4.16.37+20180207154505.git.2.6f2f0ed~1rapid7-1) ...
update-alternatives: using /opt/metasploit-framework/bin/msfbinscan to provide /usr/bin/msfbinscan (msfbinscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfconsole to provide /usr/bin/msfconsole (msfconsole) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfd to provide /usr/bin/msfd (msfd) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfdb to provide /usr/bin/msfdb (msfdb) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfelfscan to provide /usr/bin/msfelfscan (msfelfscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfmachscan to provide /usr/bin/msfmachscan (msfmachscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfpescan to provide /usr/bin/msfpescan (msfpescan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrop to provide /usr/bin/msfrop (msfrop) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrpc to provide /usr/bin/msfrpc (msfrpc) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrpcd to provide /usr/bin/msfrpcd (msfrpcd) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfupdate to provide /usr/bin/msfupdate (msfupdate) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfvenom to provide /usr/bin/msfvenom (msfvenom) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/metasploit-aggregator to provide /usr/bin/metasploit-aggregator (metasploit-aggregator) in auto mode
Run msfconsole to get started
W: --force-yes is deprecated, use one of the options starting with --allow instead.
/opt/metasploit-framework/embedded/framework/msfdb:210:in `initialize': No such file or directory @ rb_sysopen - /home/msf/.msf4/database.yml (Errno::ENOENT)
	from /opt/metasploit-framework/embedded/framework/msfdb:210:in `open'
	from /opt/metasploit-framework/embedded/framework/msfdb:210:in `init_db'
	from /opt/metasploit-framework/embedded/framework/msfdb:315:in `<main>'
The command '/bin/sh -c bash -c "sudo -H -u msf bash -c 'curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > /tmp/msfinstall && chmod 755 /tmp/msfinstall && /tmp/msfinstall && msfdb init'"' returned a non-zero code: 1
```

