### PR TITLE
updated kali/centos docker commands

### DIFF
--- a/docker/kali109_32-omnibus/Dockerfile
+++ b/docker/kali109_32-omnibus/Dockerfile
@@ -48,3 +48,6 @@ RUN git clone https://github.com/rapid7/metasploit-omnibus.git
 RUN /bin/bash -l -c "cd metasploit-omnibus && bundle install --binstubs"
 RUN rm -fr metasploit-omnibus
 RUN mkdir /metasploit-framework
+RUN /bin/bash -l -c "rvm install 2.4.1"
+RUN /bin/bash -l -c "rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc"
+RUN /bin/bash -l -c "rvm use 2.4.1 && git clone https://github.com/rapid7/metasploit-omnibus.git && cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus"

--- a/docker/kali109_64-omnibus/Dockerfile
+++ b/docker/kali109_64-omnibus/Dockerfile
@@ -48,3 +48,6 @@ RUN git clone https://github.com/rapid7/metasploit-omnibus.git
 RUN /bin/bash -l -c "cd metasploit-omnibus && bundle install --binstubs"
 RUN rm -fr metasploit-omnibus
 RUN mkdir /metasploit-framework
+RUN /bin/bash -l -c "rvm install 2.4.1"
+RUN /bin/bash -l -c "rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc"
+RUN /bin/bash -l -c "rvm use 2.4.1 && git clone https://github.com/rapid7/metasploit-omnibus.git && cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus"

--- a/docker/omnibus-centos6/Dockerfile
+++ b/docker/omnibus-centos6/Dockerfile
@@ -8,8 +8,8 @@ VOLUME /pkg
 RUN rpm -ivh http://download.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
 RUN yum upgrade -y && yum clean all
 RUN yum install -y centos-release-SCL && yum clean all
-RUN rpm --import http://apt.sw.be/RPM-GPG-KEY.dag.txt
-RUN curl -O http://apt.sw.be/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
+RUN rpm --import http://mirrors.neterra.net/repoforge/RPM-GPG-KEY.dag.txt
+RUN curl -O http://mirrors.neterra.net/repoforge/redhat/el6/en/x86_64/rpmforge/RPMS/rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
     rpm -i rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm && \
     rm rpmforge-release-0.5.3-1.el6.rf.x86_64.rpm
 


### PR DESCRIPTION
updated command for kali and centos docker builders.

Kali updates are run by extending the exsiting pushed images as follows:

```
FROM rapid7/build:kali109_32-omnibus
MAINTAINER Rapid7 Release Engineering <r7_re@rapid7.com>

RUN /bin/bash -l -c "rvm install 2.4.1"
RUN /bin/bash -l -c "rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc"
RUN /bin/bash -l -c "rvm use 2.4.1 && git clone https://github.com/rapid7/metasploit-omnibus.git && cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus"
```

centos update can build normally.