### PR TITLE
revised docker images for user rvm versions

### DIFF
--- a/docker/kali109_32-omnibus/Dockerfile
+++ b/docker/kali109_32-omnibus/Dockerfile
@@ -48,6 +48,11 @@ RUN git clone https://github.com/rapid7/metasploit-omnibus.git
 RUN /bin/bash -l -c "cd metasploit-omnibus && bundle install --binstubs"
 RUN rm -fr metasploit-omnibus
 RUN mkdir /metasploit-framework
-RUN /bin/bash -l -c "rvm install 2.4.1"
-RUN /bin/bash -l -c "rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc"
-RUN /bin/bash -l -c "rvm use 2.4.1 && git clone https://github.com/rapid7/metasploit-omnibus.git && cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus"
+RUN /usr/bin/sudo rm -rf $HOME/.rvm $HOME/.rvmrc /etc/rvmrc /etc/profile.d/rvm.sh /usr/local/rvm /usr/local/bin/rvm && \
+  /usr/bin/sudo /usr/sbin/groupdel rvm
+RUN su jenkins -c "/bin/bash -l -c 'curl -sSL https://rvm.io/mpapis.asc | gpg --import -'"
+RUN su jenkins -c "/bin/bash -l -c 'curl -sSL https://get.rvm.io | bash -s stable'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm install 2.4.1'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm use 2.4.1 && cd ~/ && git clone https://github.com/rapid7/metasploit-omnibus.git && \
+  cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus'"

--- a/docker/kali109_64-omnibus/Dockerfile
+++ b/docker/kali109_64-omnibus/Dockerfile
@@ -48,6 +48,11 @@ RUN git clone https://github.com/rapid7/metasploit-omnibus.git
 RUN /bin/bash -l -c "cd metasploit-omnibus && bundle install --binstubs"
 RUN rm -fr metasploit-omnibus
 RUN mkdir /metasploit-framework
-RUN /bin/bash -l -c "rvm install 2.4.1"
-RUN /bin/bash -l -c "rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc"
-RUN /bin/bash -l -c "rvm use 2.4.1 && git clone https://github.com/rapid7/metasploit-omnibus.git && cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus"
+RUN /usr/bin/sudo rm -rf $HOME/.rvm $HOME/.rvmrc /etc/rvmrc /etc/profile.d/rvm.sh /usr/local/rvm /usr/local/bin/rvm && \
+  /usr/bin/sudo /usr/sbin/groupdel rvm
+RUN su jenkins -c "/bin/bash -l -c 'curl -sSL https://rvm.io/mpapis.asc | gpg --import -'"
+RUN su jenkins -c "/bin/bash -l -c 'curl -sSL https://get.rvm.io | bash -s stable'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm install 2.4.1'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm use 2.4.1 && gem install bundler --no-ri --no-rdoc'"
+RUN su jenkins -c "/bin/bash -l -c 'rvm use 2.4.1 && cd ~/ && git clone https://github.com/rapid7/metasploit-omnibus.git && \
+  cd metasploit-omnibus && bundle install --binstubs && cd .. && rm -rf metasploit-omnibus'"


### PR DESCRIPTION
More updates to for the 2018 docker image to make ruby interaction more flexible.

This moves the ownership of `rvm` and `gemset` in the env into the user's scope. 