### PR TITLE
Add proper detection of /etc/system-release OSs to msfupdate.erb

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -127,14 +127,8 @@ ID=`id -u`
 if [ -f /etc/redhat-release ] ; then
   PKGTYPE=rpm
 elif [ -f /etc/system-release ] ; then
-  # /etc/redhat-release is not present on Amazon Linux. 
-  # cat out /etc/system-release and see if it is Amazon Linux.
-  if cat /etc/system-release | grep "Amazon Linux" > /dev/null; then
-    PKGTYPE=rpm
-  else
-    # Likely some other distro that uses RPM if /etc/system-release is present
-    PKGTYPE=rpm
-  fi
+  # If /etc/system-release is present, this is likely a distro that uses RPM.
+  PKGTYPE=rpm
 else
   if uname -sv | grep 'Darwin' > /dev/null; then
     PKGTYPE=pkg

--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -126,6 +126,15 @@ ID=`id -u`
 
 if [ -f /etc/redhat-release ] ; then
   PKGTYPE=rpm
+elif [ -f /etc/system-release ] ; then
+  # /etc/redhat-release is not present on Amazon Linux. 
+  # cat out /etc/system-release and see if it is Amazon Linux.
+  if cat /etc/system-release | grep "Amazon Linux" > /dev/null; then
+    PKGTYPE=rpm
+  else
+    # Likely some other distro that uses RPM if /etc/system-release is present
+    PKGTYPE=rpm
+  fi
 else
   if uname -sv | grep 'Darwin' > /dev/null; then
     PKGTYPE=pkg


### PR DESCRIPTION
This pull request adds proper detection of distros that have ```/etc/system-release``` that aren't Red Hat (e.g., Amazon Linux) to ```msfupdate.erb``` so that Metasploit can still be easily installed.

Output of ```/etc/system-release``` will look like this on Amazon Linux machines:
```shell
[ec2-user@ip-10-0-10-239 ~]$ cat /etc/system-release
Amazon Linux AMI release 2018.03
[ec2-user@ip-10-0-10-239 ~]$
```

~~This PR also allows a default to ```PKGTYPE=rpm``` if /etc/system-release is present but no specific distro has been determined.~~

Edit: I made the check more generic.