### PR TITLE
Remove extras from the installer, not true dependencies

### DIFF
--- a/config/projects/metasploit-framework-extras.rb
+++ b/config/projects/metasploit-framework-extras.rb
@@ -1,11 +1,1 @@
-name "metasploit-framework-extras"
-maintainer "Rapid7 Release Engineering <r7_re@rapid7.com>"
-homepage "https://rapid7.com"
 
-install_dir "#{default_root}/metasploit-framework-extras"
-
-build_version Omnibus::BuildVersion.semver
-build_iteration 1
-
-dependency "nmap"
-dependency "john"


### PR DESCRIPTION
John and Nmap are not necessary, and for users that use John or Nmap from source or just does not use theses tools, its only more downloading and compiling time, and conflicts