### PR TITLE
fix typo in database privs for development

### DIFF
--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -154,7 +154,7 @@ def create_db
   File.open("#{@db}/pg_hba.conf", 'w') do |f|
     f.puts "host    \"msf\"      \"#{@msf_user}\"      127.0.0.1/32           md5"
     f.puts "host    \"msftest\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
-    f.puts "host    \"postgres\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
+    f.puts "host    \"postgres\"  \"#{@msftest_user}\"  127.0.0.1/32          trust"
     f.puts "host    \"template1\"   all                127.0.0.1/32           trust"
     if Gem.win_platform?
       f.puts "host    all             all                127.0.0.1/32           trust"

--- a/config/templates/metasploit-framework/msfdb.erb
+++ b/config/templates/metasploit-framework/msfdb.erb
@@ -154,7 +154,7 @@ def create_db
   File.open("#{@db}/pg_hba.conf", 'w') do |f|
     f.puts "host    \"msf\"      \"#{@msf_user}\"      127.0.0.1/32           md5"
     f.puts "host    \"msftest\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
-    f.puts "host    \"postgresql\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
+    f.puts "host    \"postgres\"  \"#{@msftest_user}\"  127.0.0.1/32           md5"
     f.puts "host    \"template1\"   all                127.0.0.1/32           trust"
     if Gem.win_platform?
       f.puts "host    all             all                127.0.0.1/32           trust"


### PR DESCRIPTION
This should say 'postgres' to work properly.