### PR TITLE
Use msfdb from metasploit-framework

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -49,6 +49,13 @@ build do
       mode: 0755,
       vars: { install_dir: install_dir }
 
+  block "Give precedence to msfdb if found in '#{project_dir}'" do
+    if File.exist?("#{project_dir}/msfdb")
+      # install msfdb found in metasploit-framework
+      FileUtils.cp("#{project_dir}/msfdb", "#{install_dir}/embedded/framework/")
+    end
+  end
+
   unless windows?
     erb source: 'msfdb-kali.erb',
         dest: "#{install_dir}/embedded/framework/msfdb-kali",


### PR DESCRIPTION
Gives precedence to `msfdb` if found in the metasploit-framework repo, overwriting the existing `msfdb` with the enhanced `msfdb` for MSF5.

This PR should be delayed until rapid7/metasploit-framework#10410 is landed.