### PR TITLE
add sudo capability in centos docker

### DIFF
--- a/docker/omnibus-centos6/Dockerfile
+++ b/docker/omnibus-centos6/Dockerfile
@@ -80,3 +80,4 @@ RUN chown -R jenkins "$JENKINS_HOME"
 
 ENV PATH /opt/chef/embedded/bin:$PATH
 RUN mkdir /metasploit-framework
+RUN yum --enablerepo=rpmforge-extras install -y sudo && yum clean all && echo "jenkins ALL=(ALL) NOPASSWD: ALL" | tee -a /etc/sudoers


### PR DESCRIPTION
Testing infrastructure expects to use sudo, adding here to meet expectations.