### PR TITLE
whitelist all data/exploit/*

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -22,6 +22,9 @@ end
 # This depends on extra system libraries on OS X
 whitelist_file "#{install_dir}//embedded/framework/data/isight.bundle"
 
+# Files in this path are currently attached to exploits and required `bad` binaries
+whitelist_file "#{install_dir}//embedded/framework/data/exploits/.*"
+
 # This depends on libfuse
 whitelist_file "#{install_dir}/embedded/framework/data/exploits/CVE-2016-4557/hello"
 


### PR DESCRIPTION
Recent commits to framework suggest that omnibus `bad` dependency check needs to whitelist binary objects deployed as data components for modules.

https://github.com/chef/omnibus/blob/5ac799cdcc5a7865b452daa96f92812144dccb3d/lib/omnibus/health_check.rb#L443-L449

Since regex matching is supported top level `data/exploit` path can be added here to catch *most* cases.
