### PR TITLE
remove bundler doc suppression

### DIFF
--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -34,6 +34,6 @@ build do
   gem [
     "install bundler",
     v_opts,
-    "--no-ri --no-rdoc --force",
+    "--force",
   ].compact.join(" "), env: env
 end


### PR DESCRIPTION
Recent builds failed due to bundler docs suppression.

Remove the suppression for now to unblock builds.