### PR TITLE
apt-get: Replace '--force-yes' with '--allow-downgrades'

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -77,7 +77,7 @@ EOF
   apt-get update > /dev/null
   echo "OK"
   echo "Checking for and installing update.."
-  apt-get install -y --force-yes metasploit-framework
+  apt-get install -y --allow-downgrades metasploit-framework
 }
 
 install_rpm() {


### PR DESCRIPTION
**Problem:** Current installations on modern Kali and Ubuntu installations end with the following warning: `W: --force-yes is deprecated, use one of the options starting with --allow instead.`

**Proposed solution**:  Since commit 2cb132ef62ffbad739ae13612eb49f345beb6100 suggested this parameter was added to allow downgrades, let's just do that.  Replace `--force-yes` with `--allow-downgrades.

From the `apt-get` man page:
> Force yes; this is a dangerous option that will cause apt to continue without prompting if it is doing something potentially harmful `[...]` This is deprecated and replaced by `--allow-downgrades`, `--allow-remove-essential`, `--allow-change-held-packages` in 1.1.

### Previous behavior

```
administrator@ubuntu:~$ ./msfinstall
Switching to root user to update the package
[sudo] password for administrator: 
Adding metasploit-framework to your repository list..OK
[...]
Run msfconsole to get started
W: --force-yes is deprecated, use one of the options starting with --allow instead.
```

### Proposed behavior

```
administrator@ubuntu:~$ ./msfinstall
Switching to root user to update the package
[sudo] password for administrator: 
Adding metasploit-framework to your repository list..OK
[...]
Run msfconsole to get started
```