### PR TITLE
update Gemfile.lock for current versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,18 @@
 GIT
   remote: https://github.com/rapid7/omnibus
-  revision: 2d264d9e853e700ceac2e0e52ed1564070d1b152
+  revision: 3a2d7755a6179dbce07c59488fb9404a83e323a5
+  branch: r7_working
   specs:
-    omnibus (5.5.0)
+    omnibus (5.6.12)
       aws-sdk (~> 2)
       chef-sugar (~> 3.3)
       cleanroom (~> 1.0)
       ffi-yajl (~> 2.2)
-      license_scout
+      license_scout (~> 1.0)
       mixlib-shellout (~> 2.0)
       mixlib-versioning
-      ohai (~> 8.0)
+      ohai (>= 8.6.0.alpha.1, < 15)
+      pedump
       ruby-progressbar (~> 1.7)
       thor (~> 0.18)
 
@@ -18,14 +20,15 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    aws-sdk (2.10.134)
-      aws-sdk-resources (= 2.10.134)
-    aws-sdk-core (2.10.134)
+    awesome_print (1.8.0)
+    aws-sdk (2.11.202)
+      aws-sdk-resources (= 2.11.202)
+    aws-sdk-core (2.11.202)
       aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.10.134)
-      aws-sdk-core (= 2.10.134)
-    aws-sigv4 (1.0.2)
+    aws-sdk-resources (2.11.202)
+      aws-sdk-core (= 2.11.202)
+    aws-sigv4 (1.0.3)
     berkshelf (3.3.0)
       addressable (~> 2.3.4)
       berkshelf-api-client (~> 1.2)
@@ -60,10 +63,10 @@ GEM
     celluloid-io (0.16.2)
       celluloid (>= 0.16.0)
       nio4r (>= 1.1.0)
-    chef-config (13.7.16)
+    chef-config (14.8.12)
       addressable
       fuzzyurl
-      mixlib-config (~> 2.0)
+      mixlib-config (>= 2.2.12, < 3.0)
       mixlib-shellout (~> 2.0)
       tomlrb (~> 1.2)
     chef-sugar (3.6.0)
@@ -76,8 +79,7 @@ GEM
     erubis (2.7.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.21)
-    ffi (1.9.21-x86-mingw32)
+    ffi (1.10.0)
     ffi-yajl (2.3.1)
       libyajl2 (~> 1.2)
     fuzzyurl (0.9.0)
@@ -85,17 +87,17 @@ GEM
       ffi (>= 1.0.1)
     gyoku (1.3.1)
       builder (>= 2.1.2)
-    hashie (3.5.7)
-    hitimes (1.2.6)
-    hitimes (1.2.6-x86-mingw32)
+    hashie (3.6.0)
+    hitimes (1.3.0)
     httpclient (2.6.0.1)
+    iostruct (0.0.4)
     ipaddress (0.8.3)
-    jmespath (1.3.1)
+    jmespath (1.4.0)
     json (2.1.0)
-    kitchen-vagrant (1.3.0)
+    kitchen-vagrant (1.3.6)
       test-kitchen (~> 1.4)
     libyajl2 (1.2.0)
-    license_scout (1.0.0)
+    license_scout (1.0.20)
       ffi-yajl (~> 2.2)
       mixlib-shellout (~> 2.2)
       toml-rb (~> 1.0)
@@ -104,19 +106,17 @@ GEM
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
     minitar (0.5.4)
-    mixlib-authentication (1.4.2)
-    mixlib-cli (1.7.0)
-    mixlib-config (2.2.5)
-    mixlib-install (3.9.3)
+    mixlib-authentication (2.1.1)
+    mixlib-cli (2.0.1)
+    mixlib-config (2.2.18)
+      tomlrb
+    mixlib-install (3.11.5)
       mixlib-shellout
       mixlib-versioning
       thor
-    mixlib-log (1.7.1)
-    mixlib-shellout (2.3.2)
-    mixlib-shellout (2.3.2-universal-mingw32)
-      win32-process (~> 0.8.2)
-      wmi-lite (~> 1.0)
-    mixlib-versioning (1.2.2)
+    mixlib-log (2.0.9)
+    mixlib-shellout (2.4.4)
+    mixlib-versioning (1.2.7)
     multi_json (1.13.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
@@ -128,19 +128,26 @@ GEM
     nori (2.6.0)
     octokit (3.8.0)
       sawyer (~> 0.6.0, >= 0.5.3)
-    ohai (8.26.1)
-      chef-config (>= 12.5.0.alpha.1, < 14)
+    ohai (14.8.10)
+      chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
       ffi-yajl (~> 2.2)
       ipaddress
-      mixlib-cli
+      mixlib-cli (>= 1.7.0)
       mixlib-config (~> 2.0)
-      mixlib-log (>= 1.7.1, < 2.0)
+      mixlib-log (~> 2.0, >= 2.0.1)
       mixlib-shellout (~> 2.0)
       plist (~> 3.1)
       systemu (~> 2.6.4)
       wmi-lite (~> 1.0)
-    plist (3.4.0)
+    pedump (0.5.2)
+      awesome_print
+      iostruct (>= 0.0.4)
+      multipart-post (~> 2.0.0)
+      progressbar
+      zhexdump (>= 0.0.2)
+    plist (3.5.0)
+    progressbar (1.10.0)
     retryable (2.0.4)
     ridley (4.4.2)
       addressable
@@ -160,9 +167,9 @@ GEM
       retryable (~> 2.0)
       semverse (~> 1.1)
       varia_model (~> 0.4.0)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.0)
     rubyntlm (0.6.2)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
@@ -171,29 +178,27 @@ GEM
       dep_selector (~> 1.0)
       semverse (~> 1.1)
     systemu (2.6.5)
-    test-kitchen (1.20.0)
+    test-kitchen (1.24.0)
       mixlib-install (~> 3.6)
       mixlib-shellout (>= 1.2, < 3.0)
       net-scp (~> 1.1)
       net-ssh (>= 2.9, < 5.0)
       net-ssh-gateway (~> 1.2)
-      thor (~> 0.19, < 0.19.2)
+      thor (~> 0.19)
       winrm (~> 2.0)
       winrm-elevated (~> 1.0)
-      winrm-fs (~> 1.1.0)
-    thor (0.19.1)
+      winrm-fs (~> 1.1)
+    thor (0.20.3)
     timers (4.0.4)
       hitimes
-    toml-rb (1.1.1)
+    toml-rb (1.1.2)
       citrus (~> 3.0, > 3.0)
-    tomlrb (1.2.6)
+    tomlrb (1.2.8)
     vagrant-wrapper (2.0.3)
     varia_model (0.4.1)
       buff-extensions (~> 1.0)
       hashie (>= 2.0.2, < 4.0.0)
-    win32-process (0.8.3)
-      ffi (>= 1.0.0)
-    winrm (2.2.3)
+    winrm (2.3.1)
       builder (>= 2.1.2)
       erubis (~> 2.7)
       gssapi (~> 1.2)
@@ -202,19 +207,19 @@ GEM
       logging (>= 1.6.1, < 3.0)
       nori (~> 2.0)
       rubyntlm (~> 0.6.0, >= 0.6.1)
-    winrm-elevated (1.1.0)
+    winrm-elevated (1.1.1)
       winrm (~> 2.0)
       winrm-fs (~> 1.0)
-    winrm-fs (1.1.1)
+    winrm-fs (1.3.2)
       erubis (~> 2.7)
       logging (>= 1.6.1, < 3.0)
       rubyzip (~> 1.1)
       winrm (~> 2.0)
-    wmi-lite (1.0.0)
+    wmi-lite (1.0.1)
+    zhexdump (0.0.2)
 
 PLATFORMS
   ruby
-  x86-mingw32
 
 DEPENDENCIES
   berkshelf (~> 3.0)
@@ -225,4 +230,4 @@ DEPENDENCIES
   vagrant-wrapper
 
 BUNDLED WITH
-   1.16.1
+   2.0.1


### PR DESCRIPTION
While addressing issues in `4.x` branch it was identified that master `Gemfile.lock` was out of sync.