### PR TITLE
make Gemfile.lock reference 1.x compatible version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,4 +230,4 @@ DEPENDENCIES
   vagrant-wrapper
 
 BUNDLED WITH
-   2.0.1
+   1.15.0


### PR DESCRIPTION
Turns out bundler gets made with Gemfile.lock refers to a newer major version.

https://stackoverflow.com/questions/47026174/find-spec-for-exe-cant-find-gem-bundler-0-a-gemgemnotfoundexception