### PR TITLE
update dependencies to ruby 2.5

### DIFF
--- a/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
+++ b/config/patches/ruby/ruby-only-compiler-warnings-on-windows.patch
@@ -1,0 +1,16 @@
+Backporting https://github.com/ruby/ruby/commit/4f03a239dcd6704e4ae7a7029dc6b31d579e9f7c and https://github.com/ruby/ruby/commit/7184e03eb259b31a1e2fda200e63924ec4a041b3 to Ruby < 2.6.0 to solve an error preventing Nokogiri 1.8.3 from building. See https://chefio.slack.com/archives/CBFU62ZK3/p1530317076000086 for more details.
+---
+diff --git a/lib/mkmf.rb b/lib/mkmf.rb
+index 7f53bb4b97..74b42289b1 100644
+--- a/lib/mkmf.rb
++++ b/lib/mkmf.rb
+@@ -657,7 +657,8 @@ def with_ldflags(flags)
+   end
+
+   def try_ldflags(flags, opts = {})
+-    try_link(MAIN_DOES_NOTHING, flags, {:werror => true}.update(opts))
++    opts = {:werror => true}.update(opts) if $mswin
++    try_link(MAIN_DOES_NOTHING, flags, opts)
+   end
+
+   def append_ldflags(flags, *opts)

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,13 +15,16 @@
 #
 
 name "ruby-windows"
-default_version "2.4.3-2"
+default_version "2.5.3-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
 
   version "2.4.3-2" do
     source sha256: "ffd023d0aea50c3a9d7a4719c322aa46c4de54fdef55756264663ca74a7c13ea"
+  end
+  version "2.5.3-1" do
+    source sha256: "dc24e05c2c1490c74c6a7256c015cb786fb5f1898f2d8c92cbe4ca8fa271f24a"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x86.7z"
@@ -30,6 +33,9 @@ else
 
   version "2.4.3-2" do
     source sha256: "3c9ace4e96a1bc7bca2c260bf35230e17662857e20a9637bade901cf55622661"
+  end
+  version "2.5.3-1" do
+    source sha256: "eabd682a6fb886a22168f568b9c508318f045dc2e130b2668e39c4a81d340ec9"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2017, Chef Software Inc.
+# Copyright 2012-2018, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ license_file "COPYING"
 license_file "LEGAL"
 skip_transitive_dependency_licensing true
 
-default_version "2.4.3"
+# the default versions should always be the latest release of ruby
+# if you consume this definition it is your responsibility to pin
+# to the desired version of ruby. don't count on this not changing.
+default_version "2.5.3"
 
 dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 dependency "zlib"
@@ -31,13 +34,20 @@ dependency "libedit"
 dependency "libffi"
 dependency "libyaml"
 
+version("2.6.0")      { source sha256: "f3c35b924a11c88ff111f0956ded3cdc12c90c04b72b266ac61076d3697fc072" }
+version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c" }
+version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
 
+version("2.4.5")      { source sha256: "6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198" }
+version("2.4.4")      { source sha256: "254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a" }
 version("2.4.3")      { source sha256: "fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98" }
 version("2.4.2")      { source sha256: "93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c" }
 version("2.4.1")      { source sha256: "a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250" }
 version("2.4.0")      { source sha256: "152fd0bd15a90b4a18213448f485d4b53e9f7662e1508190aa5b702446b29e3d" }
 
+version("2.3.8")      { source sha256: "b5016d61440e939045d4e22979e04708ed6c8e1c52e7edb2553cf40b73c59abf" }
+version("2.3.7")      { source sha256: "35cd349cddf78e4a0640d28ec8c7e88a2ae0db51ebd8926cd232bb70db2c7d7f" }
 version("2.3.6")      { source sha256: "8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e" }
 version("2.3.5")      { source sha256: "5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc" }
 version("2.3.4")      { source sha256: "98e18f17c933318d0e32fed3aea67e304f174d03170a38fd920c4fbe49fec0c3" }
@@ -45,6 +55,7 @@ version("2.3.3")      { source sha256: "241408c8c555b258846368830a06146e4849a1d5
 version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }
 version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 
+version("2.2.10")     { source sha256: "cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358" }
 version("2.2.9")      { source sha256: "2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6" }
 version("2.2.8")      { source sha256: "8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a" }
 version("2.2.6")      { source sha256: "de8e192791cb157d610c48a9a9ff6e7f19d67ce86052feae62b82e3682cc675f" }
@@ -119,7 +130,15 @@ elsif solaris_11?
   env["CFLAGS"] << " -std=c99"
   env["CPPFLAGS"] << " -D_XOPEN_SOURCE=600 -D_XPG6"
 elsif windows?
-  env["CPPFLAGS"] << " -DFD_SETSIZE=2048"
+  env["CFLAGS"] = "-I#{install_dir}/embedded/include -DFD_SETSIZE=2048"
+  if windows_arch_i386?
+    # 32-bit windows can't compile ruby with -O2 due to compiler bugs.
+    env["CFLAGS"] << " -m32 -march=i686 -O"
+  else
+    env["CFLAGS"] << " -m64 -march=x86-64 -O2"
+  end
+  env["CPPFLAGS"] = env["CFLAGS"]
+  env["CXXFLAGS"] = env["CFLAGS"]
 else # including linux
   if version.satisfies?(">= 2.3.0") &&
       rhel? && platform_version.satisfies?("< 6.0")
@@ -195,6 +214,13 @@ build do
     patch source: "prelude_25_el6_no_pragma.patch", plevel: 0, env: patch_env
   end
 
+  # Backporting a 2.6.0 fix to 2.5.1 (and 2.4.4 for ChefDK 2). This allows us to build Nokogiri 1.8.3.
+  # Basically we only include `-Werror` linker warnings when building native gems if we are on Windows.
+  # This prevents some "expected" warnings from failing the build.
+  if version == "2.5.1" || version == "2.4.4"
+    patch source: "ruby-only-compiler-warnings-on-windows.patch", plevel: 1, env: patch_env
+  end
+
   configure_command = ["--with-out-ext=dbm,readline",
                        "--enable-shared",
                        "--disable-install-doc",
@@ -240,6 +266,11 @@ build do
     # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
     configure_command << "ac_cv_func_dl_iterate_phdr=no"
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  elsif solaris2?
+    # In ruby-2.5.0 on Solaris 11 Random.urandom defaults to arc4random_buf() as
+    # its implementation which is buggy and returns nothing but zeros.  We therefore
+    # force that API off.
+    configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
     if version.satisfies?(">= 2.3") &&
         version.satisfies?("< 2.5")


### PR DESCRIPTION
combined with updates in https://github.com/rapid7/metasploit-omnibus-cache/commit/087fa0baf4bd20e3cd08b34eb52d43d935ec0315 this brings build to ruby 2.5.3 on all platforms.

Much of this is cribbed from https://github.com/chef/omnibus-software