### PR TITLE
Fix msfdb when executed via the wrapper

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfdb.erb
+++ b/config/templates/metasploit-framework-wrappers/msfdb.erb
@@ -20,4 +20,4 @@ if [ -e /etc/os-release -a $(id -u) -eq 0 ]; then
   fi
 fi
 
-ruby "$INSTALL_DIR/embedded/framework/msfdb" "$@"
+(cd $INSTALL_DIR/embedded/framework && ruby msfdb "$@")


### PR DESCRIPTION
Fix `msfdb` when executed via the wrapper script by executing `msfdb` from within the framework directory. Fixes rapid7/metasploit-framework#11252

Thanks to @jmartin-r7 for suggestions regarding the possible issue source.

## Current output

### Running msfconsole
```
$ /opt/metasploit-framework/bin/msfconsole 

 ** Welcome to Metasploit Framework Initial Setup **
    Please answer a few questions to get started.


Would you like to use and setup a new database (recommended)? y
Creating database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/msfdev/.msf4/db/pg_hba.conf
Stopping database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating initial database schema
Initial MSF web service account username?[msfdev]: 
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...
MSF web service does not appear to be started.
Please see /home/msfdev/.msf4/logs/msf-ws.log for additional details.

 ** Metasploit Framework Initial Setup Complete **
 ...
 ```

### Running msfdb reinit

```
$ /opt/metasploit-framework/bin/msfdb reinit
Stopping database at /home/msfdev/.msf4/db
Delete all data at /home/msfdev/.msf4/db?: y
Deleting all data at /home/msfdev/.msf4/db
Delete database configuration at /home/msfdev/.msf4/database.yml?: y
Creating database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/msfdev/.msf4/db/pg_hba.conf
Stopping database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating initial database schema
MSF web service is no longer running
Initial MSF web service account username?[msfdev]: 
Either MSF web service SSL key /home/msfdev/.msf4/msf-ws-key.pem or certificate /home/msfdev/.msf4/msf-ws-cert.pem already exist, overwrite both?: y
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...
MSF web service does not appear to be started.
Please see /home/msfdev/.msf4/logs/msf-ws.log for additional details.
```

## Expected output

### Running msfconsole

 ```
 $ /opt/metasploit-framework/bin/msfconsole 

 ** Welcome to Metasploit Framework Initial Setup **
    Please answer a few questions to get started.


Would you like to use and setup a new database (recommended)? y
Creating database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/msfdev/.msf4/db/pg_hba.conf
Stopping database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating initial database schema
Initial MSF web service account username?[msfdev]: 
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...
MSF web service started and online
Creating MSF web service user msfdev

MSF web service username: msfdev
MSF web service password: oXQ8EiK+y4Lxrsn1HjOxXpXeJ8fj7mdqg6rTeSQETaw=
MSF web service user API token: 796b030ca917dfc2dae34cb7bc229deb4e4357d1113dacf09c4bce9cf4cb98c59e9b218b7b540c95
Please store these credentials securely.

MSF web service configuration complete
Connect to the data service in msfconsole using the command:
db_connect --token 796b030ca917dfc2dae34cb7bc229deb4e4357d1113dacf09c4bce9cf4cb98c59e9b218b7b540c95 --cert /home/msfdev/.msf4/msf-ws-cert.pem --skip-verify https://localhost:8080

The username and password are credentials for the API account:
https://localhost:8080/api/v1/auth/account

Add data service connection to local msfconsole and persist as default?: y
Data service connection name?[local-https-data-service]: 

 ** Metasploit Framework Initial Setup Complete **
 ...
 ```

### Running msfdb reinit

```
$ /opt/metasploit-framework/bin/msfdb reinit
Stopping database at /home/msfdev/.msf4/db
Delete all data at /home/msfdev/.msf4/db?: y
Deleting all data at /home/msfdev/.msf4/db
Delete database configuration at /home/msfdev/.msf4/database.yml?: y
Creating database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/msfdev/.msf4/db/pg_hba.conf
Stopping database at /home/msfdev/.msf4/db
Starting database at /home/msfdev/.msf4/db...success
Creating initial database schema
MSF web service is no longer running
Initial MSF web service account username?[msfdev]: 
Either MSF web service SSL key /home/msfdev/.msf4/msf-ws-key.pem or certificate /home/msfdev/.msf4/msf-ws-cert.pem already exist, overwrite both?: y
Generating SSL key and certificate for MSF web service
Attempting to start MSF web service...
MSF web service started and online
Creating MSF web service user msfdev

MSF web service username: msfdev
MSF web service password: 71gBlw8/Oblm0Mf48SdhNd24/5VDdGNzEpX+pGkb8Kg=
MSF web service user API token: 4988b0f3b57b4cbef4291bf05183b5a62c33478ab9a0c69e16386e514f86a97b32633def22d91ee4
Please store these credentials securely.

MSF web service configuration complete
Connect to the data service in msfconsole using the command:
db_connect --token 4988b0f3b57b4cbef4291bf05183b5a62c33478ab9a0c69e16386e514f86a97b32633def22d91ee4 --cert /home/msfdev/.msf4/msf-ws-cert.pem --skip-verify https://localhost:8080

The username and password are credentials for the API account:
https://localhost:8080/api/v1/auth/account

Add data service connection to local msfconsole and persist as default?: y
Data service connection name?[local-https-data-service]:
```

## Error from `~/.msf4/logs/msf-ws.log`

```
/opt/metasploit-framework/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:54:in `require': cannot load such file -- msfenv (LoadError)
	from /opt/metasploit-framework/embedded/lib/ruby/site_ruby/2.4.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /opt/metasploit-framework/embedded/framework/msf-ws.ru:10:in `block in <main>'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/rack-1.6.11/lib/rack/builder.rb:55:in `instance_eval'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/rack-1.6.11/lib/rack/builder.rb:55:in `initialize'
	from /opt/metasploit-framework/embedded/framework/msf-ws.ru:1:in `new'
	from /opt/metasploit-framework/embedded/framework/msf-ws.ru:1:in `<main>'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/rack/adapter/loader.rb:33:in `eval'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/rack/adapter/loader.rb:33:in `load'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/thin/controllers/controller.rb:182:in `load_rackup_config'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/thin/controllers/controller.rb:72:in `start'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/thin/runner.rb:203:in `run_command'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/lib/thin/runner.rb:159:in `run!'
	from /opt/metasploit-framework/embedded/lib/ruby/gems/2.4.0/gems/thin-1.7.2/bin/thin:6:in `<top (required)>'
	from /opt/metasploit-framework/embedded/bin/thin:23:in `load'
	from /opt/metasploit-framework/embedded/bin/thin:23:in `<main>'
```

## Verification

- [x] Delete `~/.msf4/initial_setup_complete`, `~/.msf4/database.yml` and `~/.msf4/db` to ensure running the `msfconsole` wrapper will prompt the user to setup a new database
- [x] Build the installer
- [x] Run the installer
- [x] Run `/opt/metasploit-framework/bin/msfconsole` and answer `yes` when prompted to setup a new database and follow addition prompts to complete the process. This should include steps for setting up the MSF web service.
- [x] **Verify** the MSF web service was successfully setup and started. The console output should include an MSF web service username, password and user API token.
