### PR TITLE
Update windows build for ruby 2.5.3

### DIFF
--- a/config/patches/metasploit-framework/bump_pg.patch
+++ b/config/patches/metasploit-framework/bump_pg.patch
@@ -1,0 +1,13 @@
+diff --git a/metasploit-framework.gemspec b/metasploit-framework.gemspec
+index 137e74da10..b55732712a 100644
+--- a/metasploit-framework.gemspec
++++ b/metasploit-framework.gemspec
+@@ -88,7 +88,7 @@ Gem::Specification.new do |spec|
+   # Used by the Metasploit data model, etc.
+   # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
+   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
+-  spec.add_runtime_dependency 'pg', '0.20.0'
++  spec.add_runtime_dependency 'pg', '1.1.4'
+   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
+   spec.add_runtime_dependency 'railties'
+   # required for OS fingerprinting

--- a/config/patches/metasploit-framework/bump_pg.patch
+++ b/config/patches/metasploit-framework/bump_pg.patch
@@ -6,7 +6,7 @@ index 137e74da10..b55732712a 100644
    # Used by the Metasploit data model, etc.
    # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
    # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
--  spec.add_runtime_dependency 'pg', '0.20.0'
+-  spec.add_runtime_dependency 'pg', '~> 0.20'
 +  spec.add_runtime_dependency 'pg', '1.1.4'
    # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
    spec.add_runtime_dependency 'railties'

--- a/config/patches/metasploit-framework/reset_pg.patch
+++ b/config/patches/metasploit-framework/reset_pg.patch
@@ -1,0 +1,13 @@
+diff --git a/metasploit-framework.gemspec b/metasploit-framework.gemspec
+index b55732712a..137e74da10 100644
+--- a/metasploit-framework.gemspec
++++ b/metasploit-framework.gemspec
+@@ -88,7 +88,7 @@ Gem::Specification.new do |spec|
+   # Used by the Metasploit data model, etc.
+   # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
+   # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
+-  spec.add_runtime_dependency 'pg', '1.1.4'
++  spec.add_runtime_dependency 'pg', '0.20.0'
+   # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
+   spec.add_runtime_dependency 'railties'
+   # required for OS fingerprinting

--- a/config/patches/metasploit-framework/reset_pg.patch
+++ b/config/patches/metasploit-framework/reset_pg.patch
@@ -7,7 +7,7 @@ index b55732712a..137e74da10 100644
    # bound to 0.20 for Activerecord 4.2.8 deprecation warnings:
    # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
 -  spec.add_runtime_dependency 'pg', '1.1.4'
-+  spec.add_runtime_dependency 'pg', '0.20.0'
++  spec.add_runtime_dependency 'pg', '~> 0.20'
    # Run initializers for metasploit-concern, metasploit-credential, metasploit_data_models Rails::Engines
    spec.add_runtime_dependency 'railties'
    # required for OS fingerprinting

--- a/config/projects/metasploit-framework.rb
+++ b/config/projects/metasploit-framework.rb
@@ -16,9 +16,12 @@ end
 exclude "**/.git"
 exclude "**/bundler/git"
 
+project_location_dir = name
 package :msi do
   upgrade_code 'A3C83F57-6D8F-453A-9559-0D650A95EB21'
   wix_light_delay_validation true
+  fast_msi true
+  parameters ProjectLocationDir: project_location_dir
 end
 
 package :appx do

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -34,6 +34,6 @@ build do
   gem [
     "install bundler",
     v_opts,
-    "--force",
+    "--force --no-document",
   ].compact.join(" "), env: env
 end

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -84,7 +84,7 @@ build do
     # Workaround missing Ruby 2.3 support for bcrypt on Windows
     # https://github.com/codahale/bcrypt-ruby/issues/139
     gem "uninstall bcrypt", env: env
-    gem "install bcrypt --platform=ruby", env: env
+    gem "install bcrypt --no-document --platform=ruby", env: env
 
     patch source: "reset_pg.patch", plevel: 1, env: env
     gem "uninstall pg -v1.1.4 --force", env: env

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -72,7 +72,6 @@ build do
   end
 
   env = with_standard_compiler_flags(with_embedded_path)
-  gem "list pg"
   bundle "install", env: env
   copy "#{project_dir}/Gemfile.lock", "#{install_dir}/embedded/framework/Gemfile.lock"
 

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -9,9 +9,9 @@ end
 
 dependency "bundler"
 dependency "pcaprub"
-dependency "pg"
 if windows?
   dependency "postgresql-windows"
+  dependency "pg"
 else
   dependency "liblzma"
   dependency "libxslt"

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -9,6 +9,7 @@ end
 
 dependency "bundler"
 dependency "pcaprub"
+dependency "pg"
 if windows?
   dependency "postgresql-windows"
 else
@@ -64,9 +65,14 @@ build do
         dest: "#{install_dir}/embedded/framework/msfdb-kali",
         mode: 0755,
         vars: { install_dir: install_dir }
+  else
+    env = with_standard_compiler_flags(with_embedded_path)
+    bundle "lock --add-platform ruby", env: env
+    bundle "config force_ruby_platform true", env: env
   end
 
   env = with_standard_compiler_flags(with_embedded_path)
+  gem "list pg"
   bundle "install", env: env
   copy "#{project_dir}/Gemfile.lock", "#{install_dir}/embedded/framework/Gemfile.lock"
 

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -12,6 +12,7 @@ dependency "pcaprub"
 if windows?
   dependency "postgresql-windows"
   dependency "pg"
+  dependency "sqlite3-gem"
 else
   dependency "liblzma"
   dependency "libxslt"

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -13,6 +13,7 @@ if windows?
   dependency "postgresql-windows"
   dependency "pg"
   dependency "sqlite3-gem"
+  sqlite3_gem_version = "-v 1.3.13"
 else
   dependency "liblzma"
   dependency "libxslt"
@@ -89,7 +90,7 @@ build do
     gem "uninstall pg -v1.1.4 --force", env: env
 
     gem "uninstall sqlite3", env: env
-    gem "install sqlite3 --no-document --platform=ruby", env: env
+    gem "install sqlite3 #{sqlite3_gem_version} --no-document --platform=ruby", env: env
 
     delete "#{install_dir}/devkit"
   end

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -68,14 +68,12 @@ build do
         mode: 0755,
         vars: { install_dir: install_dir }
   else
-    patch_env = env.dup
-    patch_env["PATH"] = "#{install_dir}/embedded/bin/msys64/usr/bin:#{env['PATH']}"
     # patch gemspec to override pg version to one with 2.5 native supplied
     # this is only a viable option because pg does not have any other dependencies
     # as some point activerecord updates or impelmentation of bunlder feature
     # requested in https://github.com/bundler/bundler/pull/6247 will allow removal
     # of this hack
-    patch source: "bump_pg.patch", plevel: 1, env: patch_env
+    patch source: "bump_pg.patch", plevel: 1, env: env
     # remove after bundle is installed
   end
 
@@ -88,7 +86,7 @@ build do
     gem "uninstall bcrypt", env: env
     gem "install bcrypt --platform=ruby", env: env
 
-    patch source: "reset_pg.patch", plevel: 1, env: patch_env
+    patch source: "reset_pg.patch", plevel: 1, env: env
     gem "uninstall pg -v1.1.4 --force", env: env
 
     delete "#{install_dir}/devkit"

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -78,7 +78,6 @@ build do
   end
 
   bundle "install", env: env
-  copy "#{project_dir}/Gemfile.lock", "#{install_dir}/embedded/framework/Gemfile.lock"
 
   if windows?
     # Workaround missing Ruby 2.3 support for bcrypt on Windows
@@ -89,6 +88,10 @@ build do
     patch source: "reset_pg.patch", plevel: 1, env: env
     gem "uninstall pg -v1.1.4 --force", env: env
 
+    gem "uninstall sqlite3", env: env
+    gem "install sqlite3 --no-document --platform=ruby", env: env
+
     delete "#{install_dir}/devkit"
   end
+  copy "#{project_dir}/Gemfile.lock", "#{install_dir}/embedded/framework/Gemfile.lock"
 end

--- a/config/software/pcaprub.rb
+++ b/config/software/pcaprub.rb
@@ -31,5 +31,5 @@ dependency "rubygems"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
   gem "install pcaprub" \
-    " --version '#{version}'", env: env
+    " --version '#{version}' --no-document", env: env
 end

--- a/config/software/pg.rb
+++ b/config/software/pg.rb
@@ -20,5 +20,5 @@ dependency "rubygems"
 build do
   env = with_standard_compiler_flags(with_embedded_path)
   gem "install pg" \
-    " -v#{version} #{pg_config}", env: env
+    " -v#{version} --no-document #{pg_config}", env: env
 end

--- a/config/software/pg.rb
+++ b/config/software/pg.rb
@@ -1,5 +1,5 @@
 name "pg"
-default_version "0.20.0"
+default_version "0.21.0"
 
 pg_config = ""
 

--- a/config/software/pg.rb
+++ b/config/software/pg.rb
@@ -1,0 +1,24 @@
+name "pg"
+default_version "0.20.0"
+
+pg_config = ""
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+  dependency "winpcap-devpack"
+  dependency "postgresql-windows"
+  dependency "bundler"
+  pg_config = "--platform=ruby -- --with-pg-config=#{install_dir}/embedded/bin/pg_config.exe"
+else
+  dependency "ruby"
+  dependency "libpcap"
+end
+
+dependency "rubygems"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "install pg" \
+    " -v#{version} #{pg_config}", env: env
+end

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "2.4.3-2"
+default_version "2.5.3-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"

--- a/config/software/sqlite.rb
+++ b/config/software/sqlite.rb
@@ -24,36 +24,20 @@ source :url => "https://sqlite.org/2015/sqlite-autoconf-3080802.tar.gz",
 relative_path "sqlite-autoconf-3080802"
 
 build do
-  if windows?
-    env = with_standard_compiler_flags(with_embedded_path)
-    cmd = ["C:/PROGRA~2/MICROS~1.0/VC/vcvarsall.bat",
-           "amd64",
-           "&&",
-           "cl",
-           "sqlite3.c",
-           "-link",
-           "-dll",
-           "-out:sqlite3.dll"
-          ].join(" ")
-    command cmd, :env => env
-    copy "#{project_dir}/sqlite3.h", "#{install_dir}/embedded/include"
-    copy "#{project_dir}/sqlite3.dll", "#{install_dir}/embedded/lib"
-  else
-    cmd = ["./configure",
-           "--prefix=#{install_dir}/embedded",
-           "--disable-readline"
-           ].join(" ")
-    env = {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
-    }
-    command cmd, :env => env
-    #command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
-    #command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}end
-    make "-j #{workers}", env: env
-    make "install", env: env
-  end
+  cmd = ["./configure",
+         "--prefix=#{install_dir}/embedded",
+         "--disable-readline"
+         ].join(" ")
+  env = {
+    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+  }
+  command cmd, :env => env
+  #command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  #command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}end
+  make "-j #{workers}", env: env
+  make "install", env: env
 end
 
 

--- a/config/software/sqlite.rb
+++ b/config/software/sqlite.rb
@@ -24,20 +24,36 @@ source :url => "https://sqlite.org/2015/sqlite-autoconf-3080802.tar.gz",
 relative_path "sqlite-autoconf-3080802"
 
 build do
-  cmd = ["./configure",
-         "--prefix=#{install_dir}/embedded",
-         "--disable-readline"
-         ].join(" ")
-  env = {
-    "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
-  }
-  command cmd, :env => env
-  #command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
-  #command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}end
-  make "-j #{workers}", env: env
-  make "install", env: env
+  if windows?
+    env = with_standard_compiler_flags(with_embedded_path)
+    cmd = ["C:/PROGRA~2/MICROS~1.0/VC/vcvarsall.bat",
+           "amd64",
+           "&&",
+           "cl",
+           "sqlite3.c",
+           "-link",
+           "-dll",
+           "-out:sqlite3.dll"
+          ].join(" ")
+    command cmd, :env => env
+    copy "#{project_dir}/sqlite3.h", "#{install_dir}/embedded/include"
+    copy "#{project_dir}/sqlite3.dll", "#{install_dir}/embedded/lib"
+  else
+    cmd = ["./configure",
+           "--prefix=#{install_dir}/embedded",
+           "--disable-readline"
+           ].join(" ")
+    env = {
+      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+    }
+    command cmd, :env => env
+    #command "make -j #{max_build_jobs}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+    #command "make install", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}end
+    make "-j #{workers}", env: env
+    make "install", env: env
+  end
 end
 
 

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -1,5 +1,5 @@
 name "sqlite3-gem"
-default_version "1.3.11"
+default_version "1.3.13"
 
 gem_config = ""
 

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -1,24 +1,20 @@
+# configure the bundler environment to build sqlite3 gem native
 name "sqlite3-gem"
-default_version "1.3.13"
-
-gem_config = ""
+default_version ""
 
 if windows?
   dependency "ruby-windows"
   dependency "ruby-windows-devkit"
+  dependency "rubygems"
   dependency "bundler"
-  gem_config = "--platform=ruby -- --with-sqlite3-include=#{install_dir}/embedded/include --with-sqlite3-lib=#{install_dir}/embedded/lib"
-else
-  dependency "ruby"
-  dependency "libpcap"
-end
+  gem_config = " --with-sqlite3-include=#{install_dir}/embedded/include --with-sqlite3-lib=#{install_dir}/embedded/lib"
 
-dependency "rubygems"
 
-build do
-  env = with_standard_compiler_flags(with_embedded_path)
-  msys_dir = "#{install_dir}/embedded/msys64"
-  command "#{msys_dir}/usr/bin/bash.exe -lc 'pacman --noconfirm -Syuu mingw-w64-x86_64-sqlite3'", env: env
-  gem "install sqlite3" \
-    " -v#{version} --no-document #{gem_config}", env: env
+  build do
+    env = with_standard_compiler_flags(with_embedded_path)
+    msys_dir = "#{install_dir}/embedded/msys64"
+    command "#{msys_dir}/usr/bin/bash.exe -lc 'pacman --noconfirm -Syuu mingw-w64-x86_64-sqlite3'", env: env
+    bundle "config build.sqlite3" \
+      "#{gem_config}", env: env
+  end
 end

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -18,6 +18,8 @@ dependency "rubygems"
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
+  msys_dir = "#{install_dir}/embedded/msys64"
+  command "#{msys_dir}/usr/bin/bash.exe -lc 'pacman --noconfirm -Syuu mingw-w64-x86_64-sqlite3'", env: env
   gem "install sqlite3" \
     " -v#{version} #{gem_config}", env: env
 end

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -1,0 +1,23 @@
+name "sqlite3-gem"
+default_version "1.3.11"
+
+gem_config = ""
+
+if windows?
+  dependency "sqlite"
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+  dependency "bundler"
+  gem_config = "--platform=ruby -- --with-sqlite3-include=#{install_dir}/embedded/include --with-sqlite3-lib=#{install_dir}/embedded/lib"
+else
+  dependency "ruby"
+  dependency "libpcap"
+end
+
+dependency "rubygems"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  gem "install sqlite3" \
+    " -v#{version} #{gem_config}", env: env
+end

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -4,7 +4,6 @@ default_version "1.3.11"
 gem_config = ""
 
 if windows?
-  dependency "sqlite"
   dependency "ruby-windows"
   dependency "ruby-windows-devkit"
   dependency "bundler"

--- a/config/software/sqlite3-gem.rb
+++ b/config/software/sqlite3-gem.rb
@@ -20,5 +20,5 @@ build do
   msys_dir = "#{install_dir}/embedded/msys64"
   command "#{msys_dir}/usr/bin/bash.exe -lc 'pacman --noconfirm -Syuu mingw-w64-x86_64-sqlite3'", env: env
   gem "install sqlite3" \
-    " -v#{version} #{gem_config}", env: env
+    " -v#{version} --no-document #{gem_config}", env: env
 end

--- a/config/software/winpcap-devpack.rb
+++ b/config/software/winpcap-devpack.rb
@@ -36,7 +36,7 @@ build do
   else
     copy "#{project_dir}/Lib/x64/*", "#{install_dir}/embedded/lib"
   end
-  mkdir "#{install_dir}/embedded/include/ruby-2.4.0"
-  copy "#{project_dir}/Include/*", "#{install_dir}/embedded/include/ruby-2.4.0"
+  mkdir "#{install_dir}/embedded/include/ruby-2.5.0"
+  copy "#{project_dir}/Include/*", "#{install_dir}/embedded/include/ruby-2.5.0"
 
 end

--- a/omnibus.rb
+++ b/omnibus.rb
@@ -47,5 +47,5 @@
 # software_gems ['omnibus-software', 'my-company-software']
 # local_software_dirs ['/path/to/local/software']
 
-# The default arch is :x64 on 64-bit build machines, let's always build 32-bit packages
+# The default arch is :x64 on 64-bit build machines
 windows_arch :x64

--- a/resources/metasploit-framework/msi/localization-en-us.wxl.erb
+++ b/resources/metasploit-framework/msi/localization-en-us.wxl.erb
@@ -16,4 +16,8 @@
   <String Id="VerifyReadyDlgInstallTitle">{\WixUI_Font_Title_White}Ready to install [ProductName]</String>
 
   <String Id="FeatureMainName"><%= friendly_name %></String>
+
+  <String Id="MinimumOSVersionMessage">This package requires minimum OS version: Windows 7/Windows Server 2008 R2 or greater.</String>
+  <String Id="DowngradeErrorMessage">A newer version of [ProductName] is already installed.</String>
+  <String Id="FileExtractionProgress">Extracting files, please wait...</String>
 </WixLocalization>

--- a/resources/metasploit-framework/msi/source.wxs.erb
+++ b/resources/metasploit-framework/msi/source.wxs.erb
@@ -15,7 +15,7 @@
       Define the minimum supported installer version (2.0).
       The install should be done for the whole machine not just the current user
     -->
-    <Package InstallerVersion="200" InstallPrivileges="elevated" Compressed="yes" InstallScope="perMachine" />
+    <Package InstallerVersion="405" InstallPrivileges="elevated" Compressed="yes" InstallScope="perMachine" />
 
     <Media Id="1" Cabinet="Project.cab" EmbedCab="yes" CompressionLevel="high" />
 

--- a/resources/metasploit-framework/msi/source.wxs.erb
+++ b/resources/metasploit-framework/msi/source.wxs.erb
@@ -29,7 +29,43 @@
       <RemoveExistingProducts After="InstallValidate" />
     </InstallExecuteSequence>
 
+    <!--
+      If fastmsi is set, custom actions will be invoked during install to unzip
+      project files, and during uninstall to remove the project folder
+    -->
+    <% if fastmsi %>
+    <SetProperty Id="FastUnzip"
+                 Value="FASTZIPDIR=[INSTALLLOCATION];FASTZIPAPPNAME=$(var.ProjectLocationDir)"
+                 Sequence="execute"
+                 Before="FastUnzip" />
+
+    <CustomAction Id="FastUnzip"
+                  BinaryKey="CustomActionFastMsiDLL"
+                  DllEntry="FastUnzip"
+                  Execute="deferred"
+                  Return="check" />
+
+    <Binary Id="CustomActionFastMsiDLL"
+            SourceFile="CustomActionFastMsi.CA.dll" />
+
+    <CustomAction Id="Cleanup"
+                  Directory="INSTALLLOCATION"
+                  ExeCommand="cmd /C &quot;rd /S /Q $(var.ProjectLocationDir)&quot;"
+                  Execute="deferred"
+                  Return="ignore" />
+
+    <InstallExecuteSequence>
+      <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
+      <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
+    </InstallExecuteSequence>
+
+    <UI>
+      <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
+    </UI>
+    <% end %>
+
     <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="INSTALLLOCATION"/>
       <Directory Id="WINDOWSVOLUME">
         <Directory Id="PROJECTLOCATION" Name="metasploit-framework" >
           <Directory Id="PROJECTLOCATIONBIN" Name="bin" >


### PR DESCRIPTION
Update windows build for ruby 2.5.3, this pushed file count over the limit for a single cab, forcing update to use the `fast_msi` omnibus conversion to have wix zip the installation and extract it where the user defines.  Resulting file grew significantly with add of requirements for native build of `pg` and `sqlite3` to supply ruby 2.5 compatible gems.