### PR TITLE
windows ruby @ 2.4.3 until compatible pg for 2.5.3

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "2.5.3-1"
+default_version "2.4.3-2"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"


### PR DESCRIPTION
Pre-compiled `pg` gem is not compatible with ruby 2.5.3, holding windows on 2.4.3 until a solution is found.