### PR TITLE
don't wrap non-existent metasploit-aggregator binaries

### DIFF
--- a/config/software/metasploit-framework-wrappers-windows.rb
+++ b/config/software/metasploit-framework-wrappers-windows.rb
@@ -33,7 +33,6 @@ build do
       vars: { install_dir: install_dir }
 
   metasploit_bins = [
-        'metasploit-aggregator',
         'msfbinscan',
         'msfconsole',
         'msfd',

--- a/config/software/metasploit-framework-wrappers.rb
+++ b/config/software/metasploit-framework-wrappers.rb
@@ -25,7 +25,6 @@ build do
   command "chmod +x #{install_dir}/bin/*"
 
   metasploit_bins = [
-        'metasploit-aggregator',
         'msfbinscan',
         'msfconsole',
         'msfd',

--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -88,15 +88,6 @@ else # Skip initialization if we're root
   fi
 fi
 
-if [ $cmd = "metasploit-aggregator" ]; then
-  `echo "exit 1 unless ['x86_64-linux', 'x86-linux', 'darwin'].include?(RUBY_PLATFORM.gsub(/.*darwin.*/, 'darwin'))" | $BIN/ruby`
-  if [ $? != 0 ]; then
-    (>&2 echo "This platform is not supported at this time.")
-    exit 0
-  fi
-  FROM_CONSOLE_PATH=true
-fi
-
 unset GEM_HOME
 unset GEM_PATH
 unset GEM_ROOT

--- a/package-scripts/metasploit-framework/postinst
+++ b/package-scripts/metasploit-framework/postinst
@@ -4,7 +4,7 @@
 # after package is installed.
 #
 
-BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom metasploit-aggregator"
+BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom"
 
 if [ -x /usr/sbin/update-alternatives -o -x /usr/bin/update-alternatives ] ; then
 	for BIN in $BINS; do

--- a/package-scripts/metasploit-framework/prerm
+++ b/package-scripts/metasploit-framework/prerm
@@ -4,7 +4,7 @@
 # prior to installing package.
 #
 
-BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom metasploit-aggregator"
+BINS="msfbinscan msfconsole msfd msfdb msfelfscan msfmachscan msfpescan msfrop msfrpc msfrpcd msfupdate msfvenom"
 
 if [ -x /usr/sbin/update-alternatives ] ; then
 	for BIN in $BINS; do


### PR DESCRIPTION
This avoids wrapping them since they don't exist currently. Fixes https://github.com/rapid7/metasploit-framework/issues/11386