### PR TITLE
Lock bcrypt gem until armhf support is restored.

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -84,7 +84,7 @@ build do
     # Workaround missing Ruby 2.3 support for bcrypt on Windows
     # https://github.com/codahale/bcrypt-ruby/issues/139
     gem "uninstall bcrypt", env: env
-    gem "install bcrypt --no-document --platform=ruby", env: env
+    gem "install bcrypt --no-document --platform=ruby -v3.1.12", env: env
 
     patch source: "reset_pg.patch", plevel: 1, env: env
     gem "uninstall pg -v1.1.4 --force", env: env


### PR DESCRIPTION
Required due to https://github.com/rapid7/metasploit-framework/pull/12148

Updates in 3.1.13 can cause native gem compile to fail due to
https://github.com/codahale/bcrypt-ruby/issues/201.