### PR TITLE
Fix invalid quote chars in MSI manufacturer field

### DIFF
--- a/resources/metasploit-framework/msi/localization-en-us.wxl.erb
+++ b/resources/metasploit-framework/msi/localization-en-us.wxl.erb
@@ -2,7 +2,7 @@
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="LANG">1033</String>
   <String Id="ProductName"><%= friendly_name %></String>
-  <String Id="ManufacturerName"><%= maintainer.encode(:xml => :attr) %></String>
+  <String Id="ManufacturerName"><%= maintainer.encode(:xml => :text) %></String>
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>


### PR DESCRIPTION
Before this commit, the MSI Manufacturer attribute contained a quoted string.  Quotes in MSI fields are considered bad practice.  This fixes the field to not include quotes.

Here's a screenshot provided by a framework MSI user:

![screenshot](https://user-images.githubusercontent.com/2836432/64791449-5e1a1600-d53d-11e9-9fb0-0071d6948fb3.png)


The ruby `encode(:xml => :attr)` method quotes the replacement result, so that:
```
Rapid7 Release Engineering <r7_re@rapid7.com>
```
becomes
```
\"Rapid7 Release Engineering &lt;r7_re@rapid7.com&gt;\"
```

Using `encode(:xml => :text)` does not quote the string, so that:
```
Rapid7 Release Engineering <r7_re@rapid7.com>
```
becomes
```
Rapid7 Release Engineering &lt;r7_re@rapid7.com&gt;
```