### PR TITLE
fix ARPHELPLINK to point to https://metasploit.com

### DIFF
--- a/resources/metasploit-framework/msi/source.wxs.erb
+++ b/resources/metasploit-framework/msi/source.wxs.erb
@@ -91,7 +91,7 @@
     <!-- UI Stuff -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>
     <Property Id="ARPPRODUCTICON" Value="project.ico" />
-    <Property Id="ARPHELPLINK" Value="http://www.getchef.com/" />
+    <Property Id="ARPHELPLINK" Value="https://metasploit.com/" />
     <Property Id="WIXUI_INSTALLDIR" Value="<%= wix_install_dir %>" />
 
     <UIRef Id="ProjectUI_InstallDir"/>


### PR DESCRIPTION
Noted in screenshot from #108 that it pointed to the wrong place.