### PR TITLE
update to Ruby 2.6.5

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -38,7 +38,7 @@ else
     source sha256: "eabd682a6fb886a22168f568b9c508318f045dc2e130b2668e39c4a81d340ec9"
   end
   version "2.6.1-1" do
-    source sha256: "53e720d866337d9289c457e97bfdb44fc70ed7e42a3dcb8dbb43f7e93147614d"
+    source sha256: "3f637d73092d3004fb1cee2d7047949aad3880042879d8de55bf661a399f06fc"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "2.5.3-1"
+default_version "2.6.1-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
@@ -36,6 +36,9 @@ else
   end
   version "2.5.3-1" do
     source sha256: "eabd682a6fb886a22168f568b9c508318f045dc2e130b2668e39c4a81d340ec9"
+  end
+  version "2.6.1-1" do
+    source sha256: "53e720d866337d9289c457e97bfdb44fc70ed7e42a3dcb8dbb43f7e93147614d"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "2.6.1-1"
+default_version "2.6.5-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
@@ -39,6 +39,9 @@ else
   end
   version "2.6.1-1" do
     source sha256: "3f637d73092d3004fb1cee2d7047949aad3880042879d8de55bf661a399f06fc"
+  end
+  version "2.6.5-1" do
+    source sha256: "9b1866e59fe1e7336c4e3231823ff24e121878ed1bac8194ad3fe5e9f2f9ef69"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2018, Chef Software Inc.
+# Copyright 2012-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,16 +25,17 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.5.3"
+default_version "2.6.1"
 
-dependency "ncurses" unless windows? || version.satisfies?(">= 2.1")
 dependency "zlib"
 dependency "openssl"
-dependency "libedit"
 dependency "libffi"
 dependency "libyaml"
 
-version("2.6.0")      { source sha256: "f3c35b924a11c88ff111f0956ded3cdc12c90c04b72b266ac61076d3697fc072" }
+version("2.6.2")      { source sha256: "a0405d2bf2c2d2f332033b70dff354d224a864ab0edd462b7a413420453b49ab" }
+version("2.6.1")      { source sha256: "17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8" }
+version("2.5.5")      { source sha256: "28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c" }
+version("2.5.4")      { source sha256: "0e4042bce749352dfcf1b9e3013ba7c078b728f51f8adaf6470ce37675e3cb1f" }
 version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c" }
 version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
@@ -58,31 +59,6 @@ version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
 version("2.2.10")     { source sha256: "cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358" }
 version("2.2.9")      { source sha256: "2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6" }
 version("2.2.8")      { source sha256: "8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a" }
-version("2.2.6")      { source sha256: "de8e192791cb157d610c48a9a9ff6e7f19d67ce86052feae62b82e3682cc675f" }
-version("2.2.5")      { source md5: "bd8e349d4fb2c75d90817649674f94be" }
-version("2.2.4")      { source md5: "9a5e15f9d5255ba37ace18771b0a8dd2" }
-version("2.2.3")      { source md5: "150a5efc5f5d8a8011f30aa2594a7654" }
-version("2.2.2")      { source md5: "326e99ddc75381c7b50c85f7089f3260" }
-version("2.2.1")      { source md5: "b49fc67a834e4f77249eb73eecffb1c9" }
-version("2.2.0")      { source md5: "cd03b28fd0b555970f5c4fd481700852" }
-
-version("2.1.9")      { source sha256: "034cb9c50676d2c09b3b6cf5c8003585acea05008d9a29fa737c54d52c1eb70c" }
-version("2.1.8")      { source md5: "091b62f0a9796a3c55de2a228a0e6ef3" }
-version("2.1.7")      { source md5: "2e143b8e19b056df46479ae4412550c9" }
-version("2.1.6")      { source md5: "6e5564364be085c45576787b48eeb75f" }
-version("2.1.5")      { source md5: "df4c1b23f624a50513c7a78cb51a13dc" }
-version("2.1.4")      { source md5: "89b2f4a197621346f6724a3c35535b19" }
-version("2.1.3")      { source md5: "74a37b9ad90e4ea63c0eed32b9d5b18f" }
-version("2.1.2")      { source md5: "a5b5c83565f8bd954ee522bd287d2ca1" }
-version("2.1.1")      { source md5: "e57fdbb8ed56e70c43f39c79da1654b2" }
-
-version("2.0.0-p645") { source md5: "49919bba0c855eaf8e247108c7933a62" }
-version("2.0.0-p594") { source md5: "a9caa406da5d72f190e28344e747ee74" }
-version("2.0.0-p576") { source md5: "2e1f4355981b754d92f7e2cc456f843d" }
-
-version("1.9.3-p550") { source md5: "e05135be8f109b2845229c4f47f980fd" }
-version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
-version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
@@ -118,14 +94,6 @@ elsif aix?
   env["SOLIBS"] = "-lm -lc"
   # need to use GNU m4, default m4 doesn't work
   env["M4"] = "/opt/freeware/bin/m4"
-elsif solaris_10?
-  if sparc?
-    # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9"
-    env["LDFLAGS"] << " -mcpu=v9"
-  else
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe"
-  end
 elsif solaris_11?
   env["CFLAGS"] << " -std=c99"
   env["CPPFLAGS"] << " -D_XOPEN_SOURCE=600 -D_XPG6"
@@ -153,16 +121,10 @@ build do
   patch_env = env.dup
   patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}" if aix?
 
-  if solaris_10? && version.satisfies?(">= 2.1")
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
-  elsif solaris_11? && version =~ /^2.1/
-    patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1, env: patch_env
-  end
-
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
   # library.  Disabling it as we do for Solaris.
-  if ios_xr? && version.satisfies?(">= 2.1")
+  if ios_xr?
     patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
   end
 
@@ -175,34 +137,15 @@ build do
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
   #
   # Also, fix paths emitted in the makefile on windows on both msys and msys2.
-  if version.satisfies?(">= 2.1")
-    patch source: "ruby-mkmf.patch", plevel: 1, env: patch_env
-    # should intentionally break and fail to apply on 2.2, patch will need to
-    # be fixed.
-  end
+  # should intentionally break and fail to apply on 2.2, patch will need to
+  # be fixed.
+  patch source: "ruby-mkmf.patch", plevel: 1, env: patch_env
 
   # Fix find_proxy with IP format proxy and domain format uri raises an exception.
   # This only affects 2.4 and the fix is expected to be included in 2.4.2
   # https://github.com/ruby/ruby/pull/1513
   if version == "2.4.0" || version == "2.4.1"
     patch source: "2.4_no_proxy_exception.patch", plevel: 1, env: patch_env
-  end
-
-  # Fix reserve stack segmentation fault when building on RHEL5 or below
-  # Currently only affects 2.1.7 and 2.2.3. This patch taken from the fix
-  # in Ruby trunk and expected to be included in future point releases.
-  # https://bugs.ruby-lang.org/issues/11602
-  if rhel? &&
-      platform_version.satisfies?("< 6") &&
-      (version == "2.1.7" || version == "2.2.3")
-    patch source: "ruby-fix-reserve-stack-segfault.patch", plevel: 1, env: patch_env
-  end
-
-  if rhel? &&
-      platform_version.satisfies?("< 6") &&
-      version.satisfies?(">= 2.4") &&
-      version.satisfies?("< 2.5")
-    patch source: "ruby_no_conversion_warnings.patch", plevel: 1, env: patch_env
   end
 
   # RHEL 6's gcc doesn't support `#pragma GCC diagnostic` inside functions, so
@@ -231,9 +174,17 @@ build do
   configure_command << "--with-ext=psych" if version.satisfies?("< 2.3")
   configure_command << "--with-bundled-md5" if fips_mode?
 
+  # jit doesn't compile on all platforms in 2.6.0
+  # we should evaluate this when new releases come out to see if we can turn it back on
+  configure_command << "--disable-jit-support" if version.satisfies?(">= 2.6")
+
   if aix?
     # need to patch ruby's configure file so it knows how to find shared libraries
-    patch source: "ruby-aix-configure.patch", plevel: 1, env: patch_env
+    if version.satisfies?(">= 2.6")
+      patch source: "ruby-aix-configure_26_and_later.patch", plevel: 1, env: patch_env
+    else
+      patch source: "ruby-aix-configure_pre26.patch", plevel: 1, env: patch_env
+    end
     # have ruby use zlib on AIX correctly
     patch source: "ruby_aix_openssl.patch", plevel: 1, env: patch_env
     # AIX has issues with ssl retries, need to patch to have it retry

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -25,21 +25,28 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.6.1"
+default_version "2.6.5"
 
 dependency "zlib"
 dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
 
+version("2.6.5")      { source sha256: "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d" }
+version("2.6.4")      { source sha256: "4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937" }
+version("2.6.3")      { source sha256: "577fd3795f22b8d91c1d4e6733637b0394d4082db659fccf224c774a2b1c82fb" }
 version("2.6.2")      { source sha256: "a0405d2bf2c2d2f332033b70dff354d224a864ab0edd462b7a413420453b49ab" }
 version("2.6.1")      { source sha256: "17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8" }
+
+version("2.5.6")      { source sha256: "1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" }
 version("2.5.5")      { source sha256: "28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c" }
 version("2.5.4")      { source sha256: "0e4042bce749352dfcf1b9e3013ba7c078b728f51f8adaf6470ce37675e3cb1f" }
 version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576734d910ee3fd538c9520846c" }
 version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
 
+version("2.4.7")      { source sha256: "cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" }
+version("2.4.6")      { source sha256: "de0dc8097023716099f7c8a6ffc751511b90de7f5694f401b59f2d071db910be" }
 version("2.4.5")      { source sha256: "6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198" }
 version("2.4.4")      { source sha256: "254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a" }
 version("2.4.3")      { source sha256: "fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98" }
@@ -54,11 +61,7 @@ version("2.3.5")      { source sha256: "5462f7bbb28beff5da7441968471ed922f964db1
 version("2.3.4")      { source sha256: "98e18f17c933318d0e32fed3aea67e304f174d03170a38fd920c4fbe49fec0c3" }
 version("2.3.3")      { source sha256: "241408c8c555b258846368830a06146e4849a1d58dcaf6b14a3b6a73058115b7" }
 version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }
-version("2.3.0")      { source md5: "e81740ac7b14a9f837e9573601db3162" }
-
-version("2.2.10")     { source sha256: "cd51019eb9d9c786d6cb178c37f6812d8a41d6914a1edaf0050c051c75d7c358" }
-version("2.2.9")      { source sha256: "2f47c77054fc40ccfde22501425256d32c4fa0ccaf9554f0d699ed436beca1a6" }
-version("2.2.8")      { source sha256: "8f37b9d8538bf8e50ad098db2a716ea49585ad1601bbd347ef84ca0662d9268a" }
+version("2.3.0")      { source sha256: "ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507" }
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
@@ -108,18 +111,13 @@ elsif windows?
   env["CPPFLAGS"] = env["CFLAGS"]
   env["CXXFLAGS"] = env["CFLAGS"]
 else # including linux
-  if version.satisfies?(">= 2.3.0") &&
-      rhel? && platform_version.satisfies?("< 6.0")
-    env["CFLAGS"] << " -O2 -g -pipe"
-  else
-    env["CFLAGS"] << " -O3 -g -pipe"
-  end
+  env["CFLAGS"] << " -O3 -g -pipe"
 end
 
 build do
   # AIX needs /opt/freeware/bin only for patch
   patch_env = env.dup
-  patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}" if aix?
+  patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
 
   # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
   # disable ruby from linking against it, but Cisco switches will not have the
@@ -137,8 +135,6 @@ build do
   # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
   #
   # Also, fix paths emitted in the makefile on windows on both msys and msys2.
-  # should intentionally break and fail to apply on 2.2, patch will need to
-  # be fixed.
   patch source: "ruby-mkmf.patch", plevel: 1, env: patch_env
 
   # Fix find_proxy with IP format proxy and domain format uri raises an exception.
@@ -171,7 +167,6 @@ build do
                        "--without-gdbm",
                        "--without-tk",
                        "--disable-dtrace"]
-  configure_command << "--with-ext=psych" if version.satisfies?("< 2.3")
   configure_command << "--with-bundled-md5" if fips_mode?
 
   # jit doesn't compile on all platforms in 2.6.0
@@ -182,6 +177,9 @@ build do
     # need to patch ruby's configure file so it knows how to find shared libraries
     if version.satisfies?(">= 2.6")
       patch source: "ruby-aix-configure_26_and_later.patch", plevel: 1, env: patch_env
+      if version.satisfies?("= 2.6.4")
+        patch source: "ruby-2.6.4-bug14834.patch", plevel: 1, env: patch_env
+      end
     else
       patch source: "ruby-aix-configure_pre26.patch", plevel: 1, env: patch_env
     end
@@ -193,8 +191,8 @@ build do
     patch source: "ruby-aix-atomic.patch", plevel: 1, env: patch_env
     patch source: "ruby-aix-vm-core.patch", plevel: 1, env: patch_env
 
-    # per IBM, just help ruby along on what it's running on
-    configure_command << "--host=powerpc-ibm-aix6.1.0.0 --target=powerpc-ibm-aix6.1.0.0 --build=powerpc-ibm-aix6.1.0.0 --enable-pthread"
+    # per IBM, just enable pthread
+    configure_command << "--enable-pthread"
 
   elsif freebsd?
     # Disable optional support C level backtrace support. This requires the

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -45,6 +45,7 @@ if version && !source
     "2.4.8" => "dc77b51449dffe5b31776bff826bf559",
     "2.6.7" => "9cd4c5bdc70b525dfacd96e471a64605",
     "2.6.8" => "40b3250f28c1d0d5cb9ff5ab2b17df6e",
+    "3.0.3" => "b7a7dd5f85485334a6cb61b7dac20cff",
   }
   known_tarballs.each do |vsn, md5|
     version vsn do

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -46,6 +46,7 @@ if version && !source
     "2.6.7" => "9cd4c5bdc70b525dfacd96e471a64605",
     "2.6.8" => "40b3250f28c1d0d5cb9ff5ab2b17df6e",
     "3.0.3" => "b7a7dd5f85485334a6cb61b7dac20cff",
+    "3.0.6" => "60d84e843b131fb87c8fd67e8fac6470",
   }
   known_tarballs.each do |vsn, md5|
     version vsn do

--- a/config/software/winpcap-devpack.rb
+++ b/config/software/winpcap-devpack.rb
@@ -36,7 +36,7 @@ build do
   else
     copy "#{project_dir}/Lib/x64/*", "#{install_dir}/embedded/lib"
   end
-  mkdir "#{install_dir}/embedded/include/ruby-2.5.0"
-  copy "#{project_dir}/Include/*", "#{install_dir}/embedded/include/ruby-2.5.0"
+  mkdir "#{install_dir}/embedded/include/ruby-2.6.0"
+  copy "#{project_dir}/Include/*", "#{install_dir}/embedded/include/ruby-2.6.0"
 
 end


### PR DESCRIPTION
Update built artifacts to use ruby 2.6.5.

Testing;
Package builds for Linux x64 and Windows x64 have be built locally and pass smoke tests.