### PR TITLE
updates for openssl-1.1.1d

### DIFF
--- a/config/patches/openssl/openssl-1.1.0f-do-not-install-docs.patch
+++ b/config/patches/openssl/openssl-1.1.0f-do-not-install-docs.patch
@@ -1,0 +1,11 @@
+--- openssl-1.1.0f/Configurations/unix-Makefile.tmpl.orig	2017-10-22 13:23:48.592533617 +0300
++++ openssl-1.1.0f/Configurations/unix-Makefile.tmpl	2017-10-22 13:26:21.199065333 +0300
+@@ -260,7 +260,7 @@
+ 	@echo "Tests are not supported with your chosen Configure options"
+ 	@ : {- output_on() if !$disabled{tests}; "" -}
+ 
+-install: install_sw install_ssldirs install_docs
++install: install_sw install_ssldirs
+ 
+ uninstall: uninstall_docs uninstall_sw
+ 

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -20,19 +20,27 @@ license "OpenSSL"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.0.2n"
+default_version "1.1.1b"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1b") { source sha256: "5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" }
+version("1.1.1a") { source sha256: "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41" }
+version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }
+version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
+version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }
 version("1.1.0g") { source sha256: "de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af" }
 version("1.1.0f") { source sha256: "12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765" }
+version("1.0.2r") { source sha256: "ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6" }
+version("1.0.2q") { source sha256: "5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" }
+version("1.0.2p") { source sha256: "50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00" }
+version("1.0.2o") { source sha256: "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" }
 version("1.0.2n") { source sha256: "370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" }
 version("1.0.2m") { source sha256: "8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f" }
 version("1.0.2l") { source sha256: "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c" }
@@ -69,21 +77,17 @@ build do
 
   configure_args = [
     "--prefix=#{install_dir}/embedded",
-    "--with-zlib-lib=#{install_dir}/embedded/lib",
-    "--with-zlib-include=#{install_dir}/embedded/include",
+    "no-comp",
     "no-idea",
     "no-mdc2",
     "no-rc5",
+    "no-ssl2",
+    "no-ssl3",
+    "no-zlib",
     "shared",
   ]
 
   configure_args += ["--with-fipsdir=#{install_dir}/embedded", "fips"] if fips_mode?
-
-  if windows?
-    configure_args << "zlib-dynamic"
-  else
-    configure_args << "zlib"
-  end
 
   configure_cmd =
     if aix?
@@ -94,11 +98,6 @@ build do
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif omnios?
       "/bin/bash ./Configure solaris-x86-gcc"
-    elsif solaris_10?
-      # This should not require a /bin/sh, but without it we get
-      # Errno::ENOEXEC: Exec format error
-      platform = sparc? ? "solaris-sparcv9-gcc" : "solaris-x86-gcc"
-      "/bin/sh ./Configure #{platform} -static-libgcc"
     elsif solaris_11?
       platform = sparc? ? "solaris64-sparcv9-gcc" : "solaris64-x86_64-gcc"
       "/bin/bash ./Configure #{platform} -static-libgcc"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -30,6 +30,7 @@ default_version "1.1.1b"
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
 version("1.1.1b") { source sha256: "5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" }
 version("1.1.1a") { source sha256: "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41" }
 version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -82,7 +82,7 @@ build do
     "no-mdc2",
     "no-rc5",
     "no-ssl2",
-    "no-ssl3",
+    "enable-ssl3",
     "no-zlib",
     "shared",
   ]

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.1.1b"
+default_version "1.1.1d"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.


### PR DESCRIPTION
Update openssl to version `1.1.1d`.

If `zlib` build integration is still desired add comments.