### PR TITLE
lock to rubygems 3.0.6 for now

### DIFF
--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -28,6 +28,8 @@ else
   dependency "ruby"
 end
 
+default_version "3.0.6"
+
 if version && !source
   # NOTE: 2.1.11 is the last version of rubygems before the 2.2.x change to native gem install location
   #


### PR DESCRIPTION
Latest rubygems release for 3.1.0 vendors bundler 2.1.0 creating
compatibilty issues. Lock for now until all relates issues can be
addressed.