### PR TITLE
disable universal libpcap build

### DIFF
--- a/config/software/libpcap.rb
+++ b/config/software/libpcap.rb
@@ -28,6 +28,7 @@ build do
 
   command "./configure" \
           " --disable-bluetooth --disable-canusb --disable-can --disable-dbus" \
+          " --disable-universal" \
           " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env


### PR DESCRIPTION
macOS 10.14 and later do not include i386 symbols, so we need to disable universal builds. Note, this was the only universal library.