### PR TITLE
Add jemalloc to ruby compilation

### DIFF
--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,0 +1,28 @@
+name "jemalloc"
+
+default_version "5.2.1"
+
+license_file "COPYING"
+
+skip_transitive_dependency_licensing true
+
+version "5.2.1" do
+  source sha256: "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
+end
+
+source url: "https://github.com/jemalloc/jemalloc/releases/download/#{version}/jemalloc-#{version}.tar.bz2"
+
+relative_path "jemalloc-#{version}"
+
+env = with_standard_compiler_flags(with_embedded_path)
+
+build do
+  configure_commands = [
+    "--prefix=#{install_dir}/embedded",
+    "--with-jemalloc-prefix="
+  ]
+
+  configure(*configure_commands, env: env)
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+end

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -69,6 +69,11 @@ relative_path "ruby-#{version}"
 
 env = with_standard_compiler_flags(with_embedded_path)
 
+jemalloc_required = linux? || windows? || mac_os_x?
+if jemalloc_required
+  dependency "jemalloc"
+end
+
 if mac_os_x?
   # -Qunused-arguments suppresses "argument unused during compilation"
   # warnings. These can be produced if you compile a program that doesn't
@@ -168,6 +173,7 @@ build do
                        "--without-tk",
                        "--disable-dtrace"]
   configure_command << "--with-bundled-md5" if fips_mode?
+  configure_command << "--with-jemalloc" if jemalloc_required
 
   # jit doesn't compile on all platforms in 2.6.0
   # we should evaluate this when new releases come out to see if we can turn it back on


### PR DESCRIPTION
When running Metasploit on linux for for long periods of time on memory bloat/fragmentation occurs.

It's possible to make use the environment variable `MALLOC_ARENA_MAX` which configures gilbc’s memory allocator to help reduce this bloat. Unfortunately this specific fix won't work for other platforms. This PR adds support to use a custom malloc implementation called [jemalloc](https://github.com/jemalloc/jemalloc/wiki/Background) (Jason Evan's malloc) which has been worked on by firefox/facebook/apple engineers to help improve memory scalability issues.

Initial tests show that jemalloc works well with Metasploit.

## Verification

I have been testing that this works with:

```
$ /opt/metasploit-framework//embedded/bin/irb
2.5.3 :001 > RbConfig::CONFIG['MAINLIBS']
 => "-lpthread -ljemalloc -ldl -lobjc" 
```

You can still configure the malloc conf at runtime too:

> MALLOC_CONF=stats_print:true /opt/metasploit-framework//embedded/bin/ruby -e "exit"

![image](https://user-images.githubusercontent.com/60357436/78154403-22409280-7434-11ea-978c-4fd31f6fe602.png)


