### PR TITLE
Remove final kitchen dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,3 @@ gem 'omnibus', git: 'https://github.com/rapid7/omnibus', branch: 'r7_working'
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.
 # gem 'omnibus-software', github: 'opscode/omnibus-software'
-
-# This development group is installed by default when you run `bundle install`,
-# You can skip these unnecessary dependencies by running
-# `bundle install --without development` to speed up build times.
-group :development do
-  gem 'nio4r', '~> 1.2.1'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,6 @@ GEM
     mixlib-shellout (2.4.4)
     mixlib-versioning (1.2.7)
     multipart-post (2.0.0)
-    nio4r (1.2.1)
     ohai (14.8.10)
       chef-config (>= 12.8, < 15)
       ffi (~> 1.9)
@@ -91,7 +90,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  nio4r (~> 1.2.1)
   omnibus!
 
 BUNDLED WITH


### PR DESCRIPTION
nio4r is no longer used after removing kitchen from metasploit-omnibus

Full context: https://github.com/rapid7/metasploit-omnibus/pull/120/files#r401754431