### PR TITLE
update ruby 2.6.6 and openssl 1.1.1f

### DIFF
--- a/config/patches/ruby/ruby-aix-configure_26_and_later.patch
+++ b/config/patches/ruby/ruby-aix-configure_26_and_later.patch
@@ -1,0 +1,19 @@
+--- ruby-2.6.0/configure.orig	2019-01-28 19:31:52.000000000 -0800
++++ ruby-2.6.0/configure	2019-01-28 19:30:18.000000000 -0800
+@@ -26791,6 +26791,7 @@
+ 			    LDSHARED="$LDSHARED ${linker_flag}-G"
+
+ fi
++			DLDFLAGS='-eInit_$(TARGET)'
+ 			EXTDLDFLAGS='-e$(TARGET_ENTRY)'
+ 			XLDFLAGS="${linker_flag}"'-bE:$(ARCHFILE)'" ${linker_flag}-brtl"
+ 			XLDFLAGS="$XLDFLAGS ${linker_flag}-blibpath:${prefix}/lib:${LIBPATH:-/usr/lib:/lib}"
+@@ -28066,7 +28067,8 @@
+ esac
+ 	done
+ 	LIBRUBYARG_SHARED='-L${libdir} -l${RUBY_SO_NAME}'
+-	LIBS="$LIBS -lm -lc"
++	LIBS="$LIBS -lm -lc -lz"
++	LIBRUBY_SO='lib$(RUBY_SO_NAME).a'
+ 	 ;; #(
+   darwin*) :

--- a/config/patches/ruby/ruby-aix-configure_pre26.patch
+++ b/config/patches/ruby/ruby-aix-configure_pre26.patch
@@ -1,0 +1,20 @@
+--- ruby-1.9.3-p547/configure.orig	2014-05-16 09:38:31 -0500
++++ ruby-1.9.3-p547/configure	2014-07-15 19:58:29 -0500
+@@ -16488,6 +16488,7 @@
+   aix*) :
+     	: ${LDSHARED='$(CC)'}
+ 			LDSHARED="$LDSHARED ${linker_flag}-G"
++			DLDFLAGS='-eInit_$(TARGET)'
+ 			EXTDLDFLAGS='-e$(TARGET_ENTRY)'
+ 			XLDFLAGS="${linker_flag}"'-bE:$(ARCHFILE)'" ${linker_flag}-brtl"
+ 			XLDFLAGS="$XLDFLAGS ${linker_flag}-blibpath:${prefix}/lib:${LIBPATH:-/usr/lib:/lib}"
+@@ -17028,7 +17029,8 @@
+ 
+ 	LIBRUBY_DLDFLAGS="${linker_flag}-bnoentry $XLDFLAGS"
+ 	LIBRUBYARG_SHARED='-L${libdir} -l${RUBY_SO_NAME}'
+-	SOLIBS='-lm -lc'
++	SOLIBS='-lm -lc -lz'
++        LIBRUBY_SO='lib$(RUBY_SO_NAME).a'
+ 	 ;; #(
+   beos*) :
+ 

--- a/config/patches/ruby/ruby-fast-load_26.patch
+++ b/config/patches/ruby/ruby-fast-load_26.patch
@@ -1,0 +1,16 @@
+diff --git a/load.c b/load.c
+index 576464fb68..ae89f63820 100644
+--- a/load.c
++++ b/load.c
+@@ -908,6 +908,11 @@ search_required(VALUE fname, volatile VALUE *path, int safe_level, feature_func
+        if (loading) *path = rb_filesystem_str_new_cstr(loading);
+        return 'r';
+     }
++    else if ((ft = rb_feature_p(ftptr, 0, FALSE, FALSE, &loading)) == 's') {
++       if (loading) *path = rb_filesystem_str_new_cstr(loading);
++       return 's';
++    }
++
+     tmp = fname;
+     type = rb_find_file_ext_safe(&tmp, loadable_ext, safe_level);
+     switch (type) {

--- a/config/patches/ruby/ruby-faster-load_26.patch
+++ b/config/patches/ruby/ruby-faster-load_26.patch
@@ -1,0 +1,11 @@
+--- a/load.c
++++ b/load.c
+@@ -605,7 +605,7 @@ rb_load_internal0(rb_execution_context_t *ec, VALUE fname, int wrap)
+ 	    rb_parser_set_context(parser, NULL, FALSE);
+ 	    ast = (rb_ast_t *)rb_parser_load_file(parser, fname);
+ 	    iseq = rb_iseq_new_top(&ast->body, rb_fstring_lit("<top (required)>"),
+-			    fname, rb_realpath_internal(Qnil, fname, 1), NULL);
++			    fname, fname, NULL);
+ 	    rb_ast_dispose(ast);
+ 	}
+         rb_exec_event_hook_script_compiled(ec, iseq, Qnil);

--- a/config/patches/ruby/ruby-no-stack-protector-strong.patch
+++ b/config/patches/ruby/ruby-no-stack-protector-strong.patch
@@ -1,0 +1,11 @@
+--- ruby-2.6.5/configure.old	2019-12-06 13:03:20.962288441 -0800
++++ ruby-2.6.5/configure	2019-12-06 13:03:32.242919275 -0800
+@@ -8409,7 +8409,7 @@
+ esac
+     if test -z "${stack_protector+set}"; then :
+ 
+-	for opt in -fstack-protector-strong -fstack-protector
++	for opt in -fstack-protector
+ do :
+ 
+ 

--- a/config/patches/ruby/ruby-win32_warning_removal_26plus.patch
+++ b/config/patches/ruby/ruby-win32_warning_removal_26plus.patch
@@ -1,0 +1,12 @@
+--- a/ext/win32/lib/Win32API.rb
++++ b/ext/win32/lib/Win32API.rb
+@@ -1,9 +1,6 @@
+ # -*- ruby -*-
+ # frozen_string_literal: true
+ 
+-# for backward compatibility
+-warn "Win32API is deprecated after Ruby 1.9.1; use fiddle directly instead", uplevel: 2
+-
+ require 'fiddle/import'
+ 
+ class Win32API

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2016 Chef Software, Inc.
+# Copyright 2012-2019, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,44 +21,29 @@ license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
 dependency "cacerts"
-dependency "makedepend" unless aix? || windows?
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.1.1d"
+default_version "1.1.1f"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1f") { source sha256: "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" }
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
-version("1.1.1b") { source sha256: "5c557b023230413dfb0756f3137a13e6d726838ccd1430888ad15bfb2b43ea4b" }
-version("1.1.1a") { source sha256: "fc20130f8b7cbd2fb918b2f14e2f429e109c31ddd0fb38fc5d71d9ffed3f9f41" }
-version("1.1.1") { source sha256: "2836875a0f89c03d0fdf483941512613a50cfb421d6fd94b9f41d7279d586a3d" }
 version("1.1.0i") { source sha256: "ebbfc844a8c8cc0ea5dc10b86c9ce97f401837f3fa08c17b2cdadc118253cf99" }
+version("1.1.0l") { source sha256: "74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148" }
 version("1.1.0h") { source sha256: "5835626cde9e99656585fc7aaa2302a73a7e1340bf8c14fd635a62c66802a517" }
-version("1.1.0g") { source sha256: "de4d501267da39310905cb6dc8c6121f7a2cad45a7707f76df828fe1b85073af" }
-version("1.1.0f") { source sha256: "12f746f3f2493b2f39da7ecf63d7ee19c6ac9ec6a4fcd8c229da8a522cb12765" }
-version("1.0.2r") { source sha256: "ae51d08bba8a83958e894946f15303ff894d75c2b8bbd44a852b64e3fe11d0d6" }
-version("1.0.2q") { source sha256: "5744cfcbcec2b1b48629f7354203bc1e5e9b5466998bbccc5b5fcde3b18eb684" }
-version("1.0.2p") { source sha256: "50a98e07b1a89eb8f6a99477f262df71c6fa7bef77df4dc83025a2845c827d00" }
-version("1.0.2o") { source sha256: "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" }
-version("1.0.2n") { source sha256: "370babb75f278c39e0c50e8c4e7493bc0f18db6867478341a832a982fd15a8fe" }
-version("1.0.2m") { source sha256: "8c6ff15ec6b319b50788f42c7abc2890c08ba5a1cdcd3810eb9092deada37b0f" }
-version("1.0.2l") { source sha256: "ce07195b659e75f4e1db43552860070061f156a98bb37b672b101ba6e3ddf30c" }
-version("1.0.2k") { source sha256: "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" }
-version("1.0.2j") { source sha256: "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" }
-version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }
-version("1.0.2h") { source sha256: "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" }
-version("1.0.2g") { source sha256: "b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" }
+version("1.0.2u") { source sha256: "ecd0c6ffb493dd06707d38b14bb4d8c2288bb7033735606569d8f90f89669d16" }
+version("1.0.2t") { source sha256: "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc" }
+version("1.0.2s") { source sha256: "cabd5c9492825ce5bd23f3c3aeed6a97f8142f606d893df216411f07d1abab96" }
 version("1.0.1u") { source sha256: "4312b4ca1215b6f2c97007503d80db80d5157f76f8f7d3febbe6b4c56ff26739" }
 version("1.0.1t") { source sha256: "4a6ee491a2fdb22e519c76fdc2a628bb3cec12762cd456861d207996c8a07088" }
 version("1.0.1s") { source sha256: "e7e81d82f3cd538ab0cdba494006d44aab9dd96b7f6233ce9971fb7c7916d511" }
-version("1.0.1r") { source sha256: "784bd8d355ed01ce98b812f873f8b2313da61df7c7b5677fcf2e57b0863a3346" }
 
 relative_path "openssl-#{version}"
 
 build do
-
   env = with_standard_compiler_flags(with_embedded_path)
   if aix?
     env["M4"] = "/opt/freeware/bin/m4"
@@ -134,10 +119,6 @@ build do
     patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
   elsif version.start_with? "1.1"
     patch source: "openssl-1.1.0f-do-not-install-docs.patch", env: patch_env
-  end
-
-  if version == "1.0.2k"
-    patch source: "openssl-1.0.2k-no-bang.patch", env: patch_env, plevel: 1
   end
 
   if windows?

--- a/config/software/ruby-windows-devkit-bash.rb
+++ b/config/software/ruby-windows-devkit-bash.rb
@@ -1,5 +1,5 @@
 #
-# Copyright:: Copyright (c) 2014 Opscode, Inc.
+# Copyright:: Copyright (c) 2014-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,8 +22,13 @@ license "GPL-3.0"
 license_file "http://www.gnu.org/licenses/gpl-3.0.txt"
 skip_transitive_dependency_licensing true
 
-dependency "ruby-windows-devkit"
-source url: "https://github.com/opscode/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
+# XXX: this depends on ruby-windows-devkit, but the caller MUST specify that dep, or else the slightly goofy
+# library build_order optimizer in omnibus will promote ruby-windows-devkit to being before direct deps of
+# the project file which will defeat our current strategy of installing devkit absolutely dead last.
+# see: https://github.com/chef/omnibus/blob/2f9687fb1a3d2459b932acb4dcb37f4cb6335f4c/lib/omnibus/library.rb#L64-L77
+#
+# dependency "ruby-windows-devkit"
+source url: "https://github.com/chef/msys-bash/releases/download/bash-#{version}/bash-#{version}-bin.tar.lzma",
        md5: "22d5dbbd9bd0b3e0380d7a0e79c3108e"
 
 relative_path "bin"

--- a/config/software/ruby-windows-devkit.rb
+++ b/config/software/ruby-windows-devkit.rb
@@ -25,17 +25,17 @@ dependency "ruby-windows-msys2"
 
 if windows_arch_i386?
   version "4.5.2-20111229-1559" do
-    source url: "http://cloud.github.com/downloads/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-tdm-32-#{version}-sfx.exe",
            md5: "4bf8f2dd1d582c8733a67027583e19a6"
   end
 
   version "4.7.2-20130224" do
-    source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-32-#{version}-1151-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-32-#{version}-1151-sfx.exe",
            md5: "9383f12958aafc425923e322460a84de"
   end
 else
   version "4.7.2-20130224" do
-    source url: "http://cdn.rubyinstaller.org/archives/devkits/DevKit-mingw64-64-#{version}-1432-sfx.exe",
+    source url: "https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-#{version}-1432-sfx.exe",
            md5: "ce99d873c1acc8bffc639bd4e764b849"
   end
 end
@@ -43,14 +43,12 @@ build do
   env = with_standard_compiler_flags(with_embedded_path)
 
   embedded_dir = "#{install_dir}/embedded"
-  devkit_dir = "#{embedded_dir}/devkit"
 
-  command "#{project_file} -y -o#{windows_safe_path(devkit_dir)}", env: env
-
-  command "echo - #{embedded_dir} > config.yml", cwd: devkit_dir
-  ruby "dk.rb install", env: env, cwd: devkit_dir
+  command "#{project_file} -y -o#{windows_safe_path(embedded_dir)}", env: env
 
   mkdir "#{install_dir}/bin"
+  command "echo - #{install_dir}/embedded > config.yml", cwd: embedded_dir
+  ruby "dk.rb install", env: env, cwd: embedded_dir
 
   # Normally we would symlink the required unix tools.
   # However with the introduction of git-cache to speed up omnibus builds,
@@ -61,14 +59,14 @@ build do
   # many gems that ship with native extensions assume tar will be available
   # in the PATH.
   {
-    "tar.exe"          => "bsdtar.exe",
+    "tar.exe" => "bsdtar.exe",
     "libarchive-2.dll" => "libarchive-2.dll",
-    "libexpat-1.dll"   => "libexpat-1.dll",
-    "liblzma-1.dll"    => "liblzma-1.dll",
-    "libbz2-2.dll"     => "libbz2-2.dll",
-    "libz-1.dll"       => "libz-1.dll",
+    "libexpat-1.dll" => "libexpat-1.dll",
+    "liblzma-1.dll" => "liblzma-1.dll",
+    "libbz2-2.dll" => "libbz2-2.dll",
+    "libz-1.dll" => "libz-1.dll",
   }.each do |target, to|
-    copy "#{devkit_dir}/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
+    copy "#{install_dir}/embedded/mingw/bin/#{to}", "#{install_dir}/bin/#{target}"
   end
 
   command "#{embedded_dir}/bin/ridk.cmd install 2 3", env: env, cwd: embedded_dir

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "2.6.5-1"
+default_version "2.6.6-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
@@ -42,6 +42,9 @@ else
   end
   version "2.6.5-1" do
     source sha256: "9b1866e59fe1e7336c4e3231823ff24e121878ed1bac8194ad3fe5e9f2f9ef69"
+  end
+  version "2.6.6-1" do
+    source sha256: "fe5ca2e3ceffa1a98051a85b4028a2bb57332ad4dbb439e377c5775e463096e3"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2019, Chef Software Inc.
+# Copyright 2012-2020, Chef Software Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,19 +25,25 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "2.6.5"
+default_version "2.6.6"
 
 dependency "zlib"
 dependency "openssl"
 dependency "libffi"
 dependency "libyaml"
 
+version("2.7.1")      { source sha256: "d418483bdd0000576c1370571121a6eb24582116db0b7bb2005e90e250eae418" }
+version("2.7.0")      { source sha256: "8c99aa93b5e2f1bc8437d1bbbefd27b13e7694025331f77245d0c068ef1f8cbe" }
+
+version("2.6.6")      { source sha256: "364b143def360bac1b74eb56ed60b1a0dca6439b00157ae11ff77d5cd2e92291" }
 version("2.6.5")      { source sha256: "66976b716ecc1fd34f9b7c3c2b07bbd37631815377a2e3e85a5b194cfdcbed7d" }
 version("2.6.4")      { source sha256: "4fc1d8ba75505b3797020a6ffc85a8bcff6adc4dabae343b6572bf281ee17937" }
 version("2.6.3")      { source sha256: "577fd3795f22b8d91c1d4e6733637b0394d4082db659fccf224c774a2b1c82fb" }
 version("2.6.2")      { source sha256: "a0405d2bf2c2d2f332033b70dff354d224a864ab0edd462b7a413420453b49ab" }
 version("2.6.1")      { source sha256: "17024fb7bb203d9cf7a5a42c78ff6ce77140f9d083676044a7db67f1e5191cb8" }
 
+version("2.5.8")      { source sha256: "6c0bdf07876c69811a9e7dc237c43d40b1cb6369f68e0e17953d7279b524ad9a" }
+version("2.5.7")      { source sha256: "0b2d0d5e3451b6ab454f81b1bfca007407c0548dea403f1eba2e429da4add6d4" }
 version("2.5.6")      { source sha256: "1d7ed06c673020cd12a737ed686470552e8e99d72b82cd3c26daa3115c36bea7" }
 version("2.5.5")      { source sha256: "28a945fdf340e6ba04fc890b98648342e3cccfd6d223a48f3810572f11b2514c" }
 version("2.5.4")      { source sha256: "0e4042bce749352dfcf1b9e3013ba7c078b728f51f8adaf6470ce37675e3cb1f" }
@@ -45,23 +51,8 @@ version("2.5.3")      { source sha256: "9828d03852c37c20fa333a0264f2490f07338576
 version("2.5.1")      { source sha256: "dac81822325b79c3ba9532b048c2123357d3310b2b40024202f360251d9829b1" }
 version("2.5.0")      { source sha256: "46e6f3630f1888eb653b15fa811d77b5b1df6fd7a3af436b343cfe4f4503f2ab" }
 
-version("2.4.7")      { source sha256: "cd6efc720ca6a622745e2bac79f45e6cd63ab0f5a53ad7eb881545f58ff38b89" }
-version("2.4.6")      { source sha256: "de0dc8097023716099f7c8a6ffc751511b90de7f5694f401b59f2d071db910be" }
-version("2.4.5")      { source sha256: "6737741ae6ffa61174c8a3dcdd8ba92bc38827827ab1d7ea1ec78bc3cefc5198" }
-version("2.4.4")      { source sha256: "254f1c1a79e4cc814d1e7320bc5bdd995dc57e08727d30a767664619a9c8ae5a" }
-version("2.4.3")      { source sha256: "fd0375582c92045aa7d31854e724471fb469e11a4b08ff334d39052ccaaa3a98" }
-version("2.4.2")      { source sha256: "93b9e75e00b262bc4def6b26b7ae8717efc252c47154abb7392e54357e6c8c9c" }
-version("2.4.1")      { source sha256: "a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250" }
-version("2.4.0")      { source sha256: "152fd0bd15a90b4a18213448f485d4b53e9f7662e1508190aa5b702446b29e3d" }
-
-version("2.3.8")      { source sha256: "b5016d61440e939045d4e22979e04708ed6c8e1c52e7edb2553cf40b73c59abf" }
-version("2.3.7")      { source sha256: "35cd349cddf78e4a0640d28ec8c7e88a2ae0db51ebd8926cd232bb70db2c7d7f" }
-version("2.3.6")      { source sha256: "8322513279f9edfa612d445bc111a87894fac1128eaa539301cebfc0dd51571e" }
-version("2.3.5")      { source sha256: "5462f7bbb28beff5da7441968471ed922f964db1abdce82b8860608acc23ddcc" }
-version("2.3.4")      { source sha256: "98e18f17c933318d0e32fed3aea67e304f174d03170a38fd920c4fbe49fec0c3" }
-version("2.3.3")      { source sha256: "241408c8c555b258846368830a06146e4849a1d58dcaf6b14a3b6a73058115b7" }
-version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }
-version("2.3.0")      { source sha256: "ba5ba60e5f1aa21b4ef8e9bf35b9ddb57286cb546aac4b5a28c71f459467e507" }
+version("2.4.10")     { source sha256: "93d06711795bfb76dbe7e765e82cdff3ddf9d82eff2a1f24dead9bb506eaf2d0" }
+version("2.4.9")      { source sha256: "f99b6b5e3aa53d579a49eb719dd0d3834d59124159a6d4351d1e039156b1c6ae" }
 
 source url: "https://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
 
@@ -103,10 +94,9 @@ elsif solaris_11?
 elsif windows?
   env["CFLAGS"] = "-I#{install_dir}/embedded/include -DFD_SETSIZE=2048"
   if windows_arch_i386?
-    # 32-bit windows can't compile ruby with -O2 due to compiler bugs.
-    env["CFLAGS"] << " -m32 -march=i686 -O"
+    env["CFLAGS"] << " -m32 -march=i686 -O3"
   else
-    env["CFLAGS"] << " -m64 -march=x86-64 -O2"
+    env["CFLAGS"] << " -m64 -march=x86-64 -O3"
   end
   env["CPPFLAGS"] = env["CFLAGS"]
   env["CXXFLAGS"] = env["CFLAGS"]
@@ -119,11 +109,49 @@ build do
   patch_env = env.dup
   patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}" if aix?
 
-  # wrlinux7/ios_xr build boxes from Cisco include libssp and there is no way to
-  # disable ruby from linking against it, but Cisco switches will not have the
-  # library.  Disabling it as we do for Solaris.
-  if ios_xr?
-    patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
+  # remove the warning that the win32 api is going away.
+  if windows?
+    if version.satisfies?(">= 2.6")
+      patch source: "ruby-win32_warning_removal_26plus.patch", plevel: 1, env: patch_env
+    else
+      patch source: "ruby-win32_warning_removal_25_and_below.patch", plevel: 1, env: patch_env
+    end
+  end
+
+  # RHEL6 has a base compiler that does not support -fstack-protector-strong, but we
+  # cannot build modern ruby on the RHEL6 base compiler, and the configure script
+  # determines that it supports that flag and so includes it and then ultimately
+  # pushes that into native gem compilations which then blows up for end users when
+  # they try to install native gems.  So, we have to hack this up to avoid using
+  # that flag on RHEL6.
+  #
+  if rhel? && platform_version.satisfies?("< 7") && version.satisfies?(">= 2.6")
+    patch source: "ruby-no-stack-protector-strong.patch", plevel: 1, env: patch_env
+  end
+
+  # accelerate requires of c-extension.
+  #
+  # this would break code which did `require "thing"` and loaded thing.so and
+  # then fiddled with the libpath and did `require "thing"` and loaded thing.rb
+  # over the top of it.  AFAIK no sane ruby code should need to do that, and the
+  # cost of this behavior in core ruby is enormous.
+  #
+  patch source: "ruby-fast-load_26.patch", plevel: 1, env: patch_env
+
+  # accelerate requires by removing a File.expand_path
+  #
+  # the expand_path here seems to be largely useless and produces a large amount
+  # of lstat(2) calls on unix, and increases the runtime of a chef-client --version
+  # test by 33% on windows.  on modern linuxen that have openat(2) it is totally
+  # useless.  this patch breaks no built-in tests on ruby on old platforms, and
+  # it is unclear why or if it is necessary (hand crafted tests designed to try to
+  # abuse it all succeeded after this test).
+  #
+  if version.satisfies?("~> 2.6.0")
+    patch source: "ruby-faster-load_26.patch", plevel: 1, env: patch_env
+  end
+  if version.satisfies?(">= 2.7")
+    patch source: "ruby-faster-load_27.patch", plevel: 1, env: patch_env
   end
 
   # disable libpath in mkmf across all platforms, it trolls omnibus and
@@ -136,13 +164,6 @@ build do
   #
   # Also, fix paths emitted in the makefile on windows on both msys and msys2.
   patch source: "ruby-mkmf.patch", plevel: 1, env: patch_env
-
-  # Fix find_proxy with IP format proxy and domain format uri raises an exception.
-  # This only affects 2.4 and the fix is expected to be included in 2.4.2
-  # https://github.com/ruby/ruby/pull/1513
-  if version == "2.4.0" || version == "2.4.1"
-    patch source: "2.4_no_proxy_exception.patch", plevel: 1, env: patch_env
-  end
 
   # RHEL 6's gcc doesn't support `#pragma GCC diagnostic` inside functions, so
   # we'll guard their inclusion more specifically. As of 2018-01-25 this is fixed
@@ -177,7 +198,7 @@ build do
     # need to patch ruby's configure file so it knows how to find shared libraries
     if version.satisfies?(">= 2.6")
       patch source: "ruby-aix-configure_26_and_later.patch", plevel: 1, env: patch_env
-      if version.satisfies?("= 2.6.4")
+      if version.satisfies?("~> 2.6.4")
         patch source: "ruby-2.6.4-bug14834.patch", plevel: 1, env: patch_env
       end
     else
@@ -200,11 +221,6 @@ build do
     configure_command << "ac_cv_header_execinfo_h=no"
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
   elsif smartos?
-    # Chef patch - sean@sean.io
-    # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
-    # patch included upstream in Ruby 2.4.1
-    patch source: "ruby-openssl-1.0.1c.patch", plevel: 1, env: patch_env unless version.satisfies?(">= 2.4.1")
-
     # Patches taken from RVM.
     # http://bugs.ruby-lang.org/issues/5384
     # https://www.illumos.org/issues/1587
@@ -221,21 +237,9 @@ build do
     # force that API off.
     configure_command << "ac_cv_func_arc4random_buf=no"
   elsif windows?
-    if version.satisfies?(">= 2.3") &&
-        version.satisfies?("< 2.5")
-      # Windows Nano Server COM libraries do not support Apartment threading
-      # instead COINIT_MULTITHREADED must be used
-      patch source: "ruby_nano.patch", plevel: 1, env: patch_env
-    end
-
     configure_command << " debugflags=-g"
   else
     configure_command << "--with-opt-dir=#{install_dir}/embedded"
-  end
-
-  # This patch is expected to be included in 2.3.5 and is already in 2.4.1.
-  if version == "2.3.4"
-    patch source: "ruby_2_3_gcc7.patch", plevel: 0, env: patch_env
   end
 
   # FFS: works around a bug that infects AIX when it picks up our pkg-config
@@ -254,6 +258,7 @@ build do
       "libwinpthread-1",
       "libstdc++-6",
     ]
+
     if windows_arch_i386?
       dlls << "libgcc_s_dw2-1"
     else
@@ -271,13 +276,11 @@ build do
       end
     end
 
-    if version.satisfies?(">= 2.4")
-      %w{ erb gem irb rdoc ri }.each do |cmd|
-        copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
-      end
+    %w{ erb gem irb rdoc ri }.each do |cmd|
+      copy "#{project_dir}/bin/#{cmd}", "#{install_dir}/embedded/bin/#{cmd}"
     end
 
-    # Ruby 2.4 seems to mark rake.bat as read-only.
+    # Ruby seems to mark rake.bat as read-only.
     # Mark it as writable so that we can install other version of rake without
     # running into permission errors.
     command "attrib -r #{install_dir}/embedded/bin/rake.bat"


### PR DESCRIPTION
Many updates cribbed from https://github.com/chef/omnibus-software

Updates build to use ruby 2.6.6 and openssl 1.1.1f.  Primary driver for Ruby update is security fixes in `2.6.6`.