### PR TITLE
Remove line about being an unofficial installer

### DIFF
--- a/resources/metasploit-framework/pkg/welcome.html.erb
+++ b/resources/metasploit-framework/pkg/welcome.html.erb
@@ -10,8 +10,6 @@ which can be added to your PATH environment variable.</p>
 command to configure, start and stop it. Run '/opt/metasploit-framework/bin/msfdb' for
 more information.</p>
 
-<p>This is an unofficial installer and a work in progress.</p>
-
 <p>If you are interested in Metasploit Framework development, see the
 <a href="https://github.com/rapid7/metasploit-framework">Github Project</a> and the
 <a href="https://github.com/rapid7/metasploit-framework/wiki">Development Wiki</a>.


### PR DESCRIPTION
I _think_ this is the official installer for Metasploit, if so - let's remove the outdated line