### PR TITLE
msfinstall compatibility with OpenSUSE

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -96,7 +96,6 @@ EOF
   yum install -y metasploit-framework
 }
 
-}
 install_suse() {
   echo "Checking for and installing update.."
   GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit

--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -96,6 +96,18 @@ EOF
   yum install -y metasploit-framework
 }
 
+}
+install_suse() {
+  echo "Checking for and installing update.."
+  GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit
+  echo -n "Adding metasploit-framework to your repository list.."
+
+  zypper ar  -f $DOWNLOAD_URI/rpm metasploit
+  print_pgp_key > ${GPG_KEY_FILE}
+  rpmkeys --import ${GPG_KEY_FILE}
+  zypper install -y metasploit-framework
+}
+
 install_pkg()
 {
   (
@@ -128,6 +140,8 @@ elif [ -f /etc/system-release ] ; then
 else
   if uname -sv | grep 'Darwin' > /dev/null; then
     PKGTYPE=pkg
+  elif [ -f /usr/bin/zypper ] ; then
+    PKGTYPE=sus
   else
     PKGTYPE=deb
   fi
@@ -147,6 +161,9 @@ fi
 case $PKGTYPE in
   deb)
     install_deb
+    ;;
+  sus)
+    install_suse
     ;;
   rpm)
     install_rpm


### PR DESCRIPTION
Adding a method for installing using zypper, with respective conditionals

Prior to using changed version of msfinstall:

- metasploit-framework is not installed

```
> zypper se metasploit
Loading repository data...
Reading installed packages...
No matching items found.
```

- GPG key is not present where it will be installed

```
> [ -f /etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit ]
> echo $?
1
```

Running the msfinstall script with changes:

- package installs with no errors

```
> ./msfinstall
Switching to root user to update the package
Checking for and installing update..
Adding repository 'metasploit' ...............................................................[done]
Repository 'metasploit' successfully added

URI         : http://downloads.metasploit.com/data/releases/metasploit-framework/rpm
Enabled     : Yes
GPG Check   : Yes
Autorefresh : Yes
Priority    : 99 (default priority)

Repository priorities are without effect. All enabled repositories share the same priority.
Retrieving repository 'metasploit' metadata ..................................................[done]
Building repository 'metasploit' cache .......................................................[done]
Loading repository data...
Reading installed packages...
Resolving package dependencies...

The following NEW package is going to be installed:
  metasploit-framework

1 new package to install.
Overall download size: 212.0 MiB. Already cached: 0 B. After the operation, additional 480.1 MiB
will be used.
Continue? [y/n/v/...? shows all options] (y): y
Retrieving package metasploit-framework-5.0.96+20200630102458~1rapid7-1.el6.x86_64
                                                               (1/1), 212.0 MiB (480.1 MiB unpacked)
Retrieving: metasploit-framework-5.0.96+20200630102458~1rapid7-1.el6.x86_64.rpm .[done (10.0 MiB/s)]

Checking for file conflicts: .................................................................[done]
(1/1) Installing: metasploit-framework-5.0.96+20200630102458~1rapid7-1.el6.x86_64 ............[done]
Additional rpm output:
update-alternatives: using /opt/metasploit-framework/bin/msfbinscan to provide /usr/bin/msfbinscan (msfbinscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfconsole to provide /usr/bin/msfconsole (msfconsole) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfd to provide /usr/bin/msfd (msfd) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfdb to provide /usr/bin/msfdb (msfdb) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfelfscan to provide /usr/bin/msfelfscan (msfelfscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfmachscan to provide /usr/bin/msfmachscan (msfmachscan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfpescan to provide /usr/bin/msfpescan (msfpescan) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrop to provide /usr/bin/msfrop (msfrop) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrpc to provide /usr/bin/msfrpc (msfrpc) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfrpcd to provide /usr/bin/msfrpcd (msfrpcd) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfupdate to provide /usr/bin/msfupdate (msfupdate) in auto mode
update-alternatives: using /opt/metasploit-framework/bin/msfvenom to provide /usr/bin/msfvenom (msfvenom) in auto mode
Run msfconsole to get started

```

msfconsole runs as intended

```
> msfconsole
                                                  

 ______________________________________________________________________________
|                                                                              |
|                          3Kom SuperHack II Logon                             |
|______________________________________________________________________________|
|                                                                              |
|                                                                              |
|                                                                              |
|                 User Name:          [   security    ]                        |
|                                                                              |
|                 Password:           [               ]                        |
|                                                                              |
|                                                                              |
|                                                                              |
|                                   [ OK ]                                     |
|______________________________________________________________________________|
|                                                                              |
|                                                       https://metasploit.com |
|______________________________________________________________________________|


       =[ metasploit v5.0.96-dev-                         ]
+ -- --=[ 2040 exploits - 1102 auxiliary - 344 post       ]
+ -- --=[ 562 payloads - 45 encoders - 10 nops            ]
+ -- --=[ 7 evasion                                       ]

Metasploit tip: Open an interactive Ruby terminal with irb

msf5 > 
```

# Verification

* Copy `metasploit-omnibus/blob/master/config/templates/metasploit-framework-wrappers/msfupdate.erb` to `~/msfinstall`
* run `chmod 755 msfinstall`
* run `~/msfinstall`
* run `zypper ref && zypper se metasploit-framework` to verify metasploit-framework was installed properly and repos are healthy
