### PR TITLE
unlock bcrypt version

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -84,7 +84,7 @@ build do
     # Workaround missing Ruby 2.3 support for bcrypt on Windows
     # https://github.com/codahale/bcrypt-ruby/issues/139
     gem "uninstall bcrypt", env: env
-    gem "install bcrypt --no-document --platform=ruby -v3.1.12", env: env
+    gem "install bcrypt --no-document --platform=ruby", env: env
 
     patch source: "reset_pg.patch", plevel: 1, env: env
     gem "uninstall pg -v1.1.4 --force", env: env


### PR DESCRIPTION
unlock bcrypt now that armhf support is restored

see https://github.com/rapid7/metasploit-framework/pull/13894
see #103 