### PR TITLE
install_suse(): check if gpg key file dir exists

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -98,9 +98,12 @@ EOF
 
 install_suse() {
   echo "Checking for and installing update.."
-  GPG_KEY_FILE=/etc/pki/rpm-gpg/RPM-GPG-KEY-Metasploit
+  GPG_KEY_FILE_DIR=/etc/pki/rpm-gpg
+  GPG_KEY_FILE=${GPG_KEY_FILE_DIR}/RPM-GPG-KEY-Metasploit
   echo -n "Adding metasploit-framework to your repository list.."
-
+  if [ ! -d $GPG_KEY_FILE_DIR ]; then
+    mkdir -p $GPG_KEY_FILE_DIR
+  fi
   zypper ar  -f $DOWNLOAD_URI/rpm metasploit
   print_pgp_key > ${GPG_KEY_FILE}
   rpmkeys --import ${GPG_KEY_FILE}


### PR DESCRIPTION
The defined location (/etc/pki/rpm-gpg) for  the gpg key file does not exists by
default in OpenSUSE.

This commit adds a check whether that directory exists, and creates it
if needed.

Making sure the specified directory exists prevents the situation where
the gpg key file cannot be written because the directory did not
exists---which subsequently results in zypper failing to read the
nonexistent key file and finally not accepting the added repository.

This PR addresses the issue #139. 