### PR TITLE
force ruby platform for bundle

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -69,6 +69,9 @@ build do
         vars: { install_dir: install_dir }
   end
 
+  unless windows?
+    bundle "config set force_ruby_platform true", env: env
+  end
   bundle "install", env: env
 
   if windows?


### PR DESCRIPTION
Due to update in nokogiri, builds need to force compile to be compatible with older glibc environments.

```
ERROR: It looks like you're trying to use Nokogiri as a precompiled native gem on a system with glibc < 2.17
```