### PR TITLE
update msys2 for new signer

### DIFF
--- a/config/software/ruby-windows-msys2.rb
+++ b/config/software/ruby-windows-msys2.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows-msys2"
-default_version "20200903"
+default_version "20210604"
 
 license "BSD-3-Clause"
 license_file "https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/LICENSE"
@@ -37,6 +37,12 @@ else
     # file has to be decompressed from local cache using xz before build executes
     source url: "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-#{version}.tar",
            sha256: "4507c02cf6c6e4f3de236a89b33e386a396b28ca1c57ad499740d1a7679685d8"
+    relative_path "msys64"
+  end
+  version "20210604" do
+    # file has to be decompressed from local cache using xz before build executes
+    source url: "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-#{version}.tar",
+           sha256: "8738e8f0d3e096a8bf581f9ceb674afdcc2fe3202dd1d69f39d9b8d7e3a5e099"
     relative_path "msys64"
   end
 end


### PR DESCRIPTION
Update the msys2 base packager to ensure new signers of packages are available.

As of Jun 19, 2021, some packages have a signer not in the `20200903` installed signature set.