### PR TITLE
Use exec before calling console cmds

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -106,11 +106,11 @@ if [ -e "$FRAMEWORK/$cmd" ]; then
     cmd="$cmd $db_args"
   fi
 
-  $BIN/ruby $FRAMEWORK/$cmd "$@"
+  exec $BIN/ruby $FRAMEWORK/$cmd "$@"
 else
   if [ "$FROM_CONSOLE_PATH" = true ]; then
     (cd $FRAMEWORK && $BIN/ruby $BIN/$cmd "$@")
   else
-    $BIN/ruby $BIN/$cmd "$@"
+    exec $BIN/ruby $BIN/$cmd "$@"
   fi
 fi


### PR DESCRIPTION
### Before

Pressing `ctrl+z` from within the context of a Meterpreter session backgrounds the parent warpper script as well as msfconsole immediately:
```
meterpreter > 

Background session 2? [y/N]  [1]+  Stopped                 msfconsole
a@ubuntu:~$ 

[*] Backgrounding foreground process in the shell session
```

### After

The `ctrl+z` signal is now correctly sent to msfconsole as expected, and the parent wrapper script process no longer exists to be backgrounded:
```
msf6 payload(cmd/windows/powershell_reverse_tcp) > sessions -i -1
[*] Starting interaction with 2...

meterpreter > 
Background session 2? [y/N]  
[*] Backgrounding foreground process in the shell session

meterpreter > Pressing Y/N now works as expected
```

### Verification

- Run the `msfconsole` wrapper script
- Open a windows Meterpreter shell
- Press `ctrl+z` to see the background confirmation message from msfconsole itself, and choosing `n` will still keep meterpreter the foreground
- Verify pressing `ctrl+z` within Meterpreter, choosing `y`, and backgrounding again, will still allow users to background msfconsole as expected.