### PR TITLE
moving from apt-get to apt

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -72,10 +72,10 @@ Pin-Priority: 1000
 EOF
   fi
   echo -n "Updating package cache.."
-  apt-get update > /dev/null
+  apt update > /dev/null
   echo "OK"
   echo "Checking for and installing update.."
-  apt-get install -y --allow-downgrades metasploit-framework
+  apt install -y --allow-downgrades metasploit-framework
 }
 
 install_rpm() {


### PR DESCRIPTION
reason for suggesting change:
 
1. newer suggested tooling
2. doesn't store cache of packages so saves space
ref: https://askubuntu.com/a/897605


I understand that the recommendation as per apt man pages is to keep apt-get instead of apt however in this specific script we are unnecessarily storing the cache using apt removes that cache. also those functional enough to understand that the cache should be clean would probably not be using this script anyways.