### PR TITLE
Update to postgres 13.6

### DIFF
--- a/config/software/postgresql-windows.rb
+++ b/config/software/postgresql-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql-windows"
-default_version "9.6.20"
+default_version "13.6"
 
 relative_path "pgsql"
 
@@ -46,6 +46,10 @@ if windows_arch_i386?
 
   source url: "http://get.enterprisedb.com/postgresql/postgresql-#{version}-1-windows-binaries.zip"
 else
+  version "13.6" do
+    source sha256: "44ba5f480c45afa554bf70688c025a7298a96b5541a1c302e6223988768e83a8"
+  end
+
   version "9.6.20" do
     source sha256: "a76e41e3101e09a2e772a26f0b93b405a97482b42b0695893465f3533c76d326"
   end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -15,7 +15,7 @@
 #
 
 name "postgresql"
-default_version "9.6.20"
+default_version "13.6"
 
 license "PostgreSQL"
 license_file "COPYRIGHT"
@@ -27,6 +27,8 @@ dependency "libedit"
 dependency "libuuid" unless mac_os_x?
 dependency "ncurses"
 dependency "config_guess"
+
+version("13.6")   { source sha256: "bafc7fa3d9d4da8fe71b84c63ba8bdfe8092935c30c0aa85c24b2c08508f67fc" }
 
 version "9.6.20" do
   source sha256: "3d08cba409d45ab62d42b24431a0d55e7537bcd1db2d979f5f2eefe34d487bb6"


### PR DESCRIPTION
Draft PR for now: Just verifying if CI will build, and we also need some glue code in metasploit-framework to detect unsupported postgres versions.