### PR TITLE
Fix msfconsole wrappers working without stdin available

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfwrapper.erb
+++ b/config/templates/metasploit-framework-wrappers/msfwrapper.erb
@@ -25,8 +25,7 @@ add_path() {
 
 check_db() {
   if [ ! -e $LOCALCONF/database.yml ]; then
-    while true; do
-      read -p "Would you like to use and setup a new database (recommended)? " yn
+    while read -p "Would you like to use and setup a new database (recommended)? " yn; do
       case $yn in
         [Yy]* ) $SCRIPTDIR/msfdb init; break;;
         [Nn]* ) break;;
@@ -38,14 +37,13 @@ check_db() {
 
 check_path() {
   if ! hash $cmd 2>/dev/null; then
-    while true; do
-      read -p "Would you like to add $cmd and other programs to your default PATH? " yn
-        case $yn in
-          [Yy]* ) add_path; break;;
-          [Nn]* ) break;;
-              * ) echo "Please answer yes or no.";;
-        esac
-      done
+    while read -p "Would you like to add $cmd and other programs to your default PATH? " yn; do
+      case $yn in
+        [Yy]* ) add_path; break;;
+        [Nn]* ) break;;
+            * ) echo "Please answer yes or no.";;
+      esac
+    done
   fi
 }
 


### PR DESCRIPTION
Fixes https://github.com/rapid7/metasploit-framework/issues/16355

### Before

When running `msfconsole` for the first time via the omnibus installer you are presented with setup questions:
```
 $ msfconsole

 ** Welcome to Metasploit Framework Initial Setup **
    Please answer a few questions to get started.


Would you like to use and setup a new database (recommended)? y
[?] Would you like to init the webservice? (Not Required) [no]: 
Clearing http web data service credentials in msfconsole
```

Unfortunately the act of clearing the web service credentials on msfconsole, invokes an additional call to `msfconsole`, which ends up re-asking the same msfconsole setup questions and looping indefinitely. This can be seen with strace:

```
write(1, "Please answer yes or no.\n", 25) = 25
rt_sigprocmask(SIG_BLOCK, [CHLD], [], 8) = 0
rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
ioctl(0, TCGETS, 0x7ffe7d3c81b0)        = -1 ENOTTY (Inappropriate ioctl for device)
lseek(0, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
read(0, "", 1)                          = 0
write(1, "Please answer yes or no.\n", 25) = 25
rt_sigprocmask(SIG_BLOCK, [CHLD], [], 8) = 0
rt_sigprocmask(SIG_SETMASK, [], NULL, 8) = 0
ioctl(0, TCGETS, 0x7ffe7d3c81b0)        = -1 ENOTTY (Inappropriate ioctl for device)
lseek(0, 0, SEEK_CUR)                   = -1 ESPIPE (Illegal seek)
read(0, "", 1)                          = 0
...
```

### After

The `while true` loop is removed, and setup works as expected:
```
a@ubuntu:~/Downloads$ msfconsole

 ** Welcome to Metasploit Framework Initial Setup **
    Please answer a few questions to get started.


Would you like to use and setup a new database (recommended)? y
[?] Would you like to init the webservice? (Not Required) [no]: no
Clearing http web data service credentials in msfconsole
Running the 'init' command for the database:
Creating database at /home/a/.msf4/db
Starting database at /home/a/.msf4/db...success
Creating database users
Writing client authentication configuration file /home/a/.msf4/db/pg_hba.conf
Stopping database at /home/a/.msf4/db
Starting database at /home/a/.msf4/db...success
Creating initial database schema

 ** Metasploit Framework Initial Setup Complete **

                                                  
                                   ___          ____
                               ,-""   `.      < HONK >
                             ,'  _   e )`-._ /  ----
                            /  ,' `-._<.===-'
                           /  /
                          /  ;
              _          /   ;
 (`._    _.-"" ""--..__,'    |
 <_  `-""                     \
  <`-                          :
   (__   <__.                  ;
     `-.   '-.__.      _.'    /
        \      `-.__,-'    _,'
         `._    ,    /__,-'
            ""._\__,'< <____
                 | |  `----.`.
                 | |        \ `.
                 ; |___      \-``
                 \   --<
                  `.`.<
                    `-'



       =[ metasploit v6.1.39-dev-                         ]
+ -- --=[ 2212 exploits - 1171 auxiliary - 396 post       ]
+ -- --=[ 615 payloads - 45 encoders - 11 nops            ]
+ -- --=[ 9 evasion                                       ]

Metasploit tip: After running db_nmap, be sure to 
check out the result of hosts and services

msf6 > 
```

## Validation steps

Verify the same steps as https://github.com/rapid7/metasploit-framework/issues/16355 and that there is no longer any hanging on setup