### PR TITLE
install_deb(): replace deprecated apt-key usage

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -60,9 +60,10 @@ EOF
 install_deb() {
   LIST_FILE=/etc/apt/sources.list.d/metasploit-framework.list
   PREF_FILE=/etc/apt/preferences.d/pin-metasploit.pref
-  echo -n "Adding metasploit-framework to your repository list.."
-  echo "deb $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
-  print_pgp_key | apt-key add -
+  GPG_KEY_FILE=/usr/share/keyrings/metasploit-framework.gpg
+  echo "Adding metasploit-framework to your repository list.."
+  print_pgp_key | sudo gpg --dearmor -o $GPG_KEY_FILE
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=$GPG_KEY_FILE] $DOWNLOAD_URI/apt lucid main" | sudo tee $LIST_FILE > /dev/null
   if [ ! -f $PREF_FILE ]; then
     mkdir -p /etc/apt/preferences.d/
     cat > $PREF_FILE <<EOF


### PR DESCRIPTION
`install_deb()` in the Nightly Installer msfupdate.erb script uses the deprecated `apt-key` for saving the metasploit gpg key

As per the apt-key man page:
> Use of apt-key is deprecated, except for the use of apt-key del in maintainer scripts to remove existing keys from the main keyring. If such usage of apt-key is desired the additional installation of the GNU Privacy Guard suite (packaged in gnupg) is required.

> apt-key(8) will last be available in Debian 11 and Ubuntu 22.04.

Updated to remove use of this deprecated utility.