### PR TITLE
update msys2 due to new signer

### DIFF
--- a/config/software/ruby-windows-msys2.rb
+++ b/config/software/ruby-windows-msys2.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows-msys2"
-default_version "20220118"
+default_version "20220603"
 
 license "BSD-3-Clause"
 license_file "https://raw.githubusercontent.com/Alexpux/MSYS2-packages/master/LICENSE"
@@ -49,6 +49,12 @@ else
     # file has to be decompressed from local cache using xz before build executes
     source url: "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-#{version}.tar",
            sha256: "f4f428797a285d29225aebd535d83a4f530fdc3870d8b0a8afa784532472e19d"
+    relative_path "msys64"
+  end
+  version "20220603" do
+    # file has to be decompressed from local cache using xz before build executes
+    source url: "https://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-#{version}.tar",
+           sha256: "39e476b45b7ca39567afd341146af68ed53b89b09c90d285988367ec5c5ecc11"
     relative_path "msys64"
   end
 end


### PR DESCRIPTION
Some upstream packages required for build have a new signer requiring a new base msys2.

```
10:09:51 Install MSYS2 and MINGW development toolchain ...

10:09:51 > pacman -S --needed --noconfirm autoconf autogen automake-wrapper diffutils file gawk grep libtool m4 make patch sed texinfo texinfo-tex wget mingw-w64-x86_64-binutils mingw-w64-x86_64-crt-git mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-headers-git mingw-w64-x86_64-libmangle-git mingw-w64-x86_64-libwinpthread-git mingw-w64-x86_64-make mingw-w64-x86_64-tools-git mingw-w64-x86_64-winpthreads-git pkgconf mingw-w64-x86_64-pkgconf

10:09:51 warning: file-5.41-2 is up to date -- skipping
10:09:51 warning: gawk-5.1.0-2 is up to date -- skipping
10:09:51 warning: grep-1~3.0-3 is up to date -- skipping
10:09:51 warning: sed-4.8-2 is up to date -- skipping
10:09:51 warning: wget-1.21.2-1 is up to date -- skipping
10:09:51 error: mingw-w64-x86_64-libiconv: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
10:09:51 error: mingw-w64-x86_64-zlib: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
10:09:51 error: mingw-w64-x86_64-mpc: signature from "David Macek <david.macek.0@gmail.com>" is unknown trust
10:09:51 error: failed to commit transaction (invalid or corrupted package)
10:09:51 Install MSYS2 and MINGW development toolchain [31mfailed[0m
```

Upstream submodule for the cache repo includes postgres package not used by this PR, this seems reasonable to leave in place vs adjusting the cache repo at this time.