### PR TITLE
update sqlite3 gem config

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -36,7 +36,7 @@ whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/m
 # Also whitelist mettle
 whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/metasploit_payloads.*"
 
-# Also whitelist sqlite deps to as libz is provided just not first on path
+# Also whitelist sqlite deps too as libz is provided just not first on path
 whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/sqlite3-.*"
 
 build do

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -36,6 +36,9 @@ whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/m
 # Also whitelist mettle
 whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/metasploit_payloads.*"
 
+# Also whitelist sqlite deps to as libz is provided just not first on path
+whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/sqlite3-.*"
+
 build do
   copy "#{project_dir}", "#{install_dir}/embedded/framework"
 
@@ -73,10 +76,8 @@ build do
         vars: { install_dir: install_dir }
   end
 
-  if windows?
-    sqlite_config = " --with-sqlite3-include=#{install_dir}/embedded/include --with-sqlite3-lib=#{install_dir}/embedded/lib"
-    bundle "config set build.sqlite3 #{sqlite_config}", env: env
-  end
+  sqlite_config = "--enable-system-libraries --with-sqlite3-include=#{install_dir}/embedded/include --with-sqlite3-lib=#{install_dir}/embedded/lib"
+  bundle "config set build.sqlite3 #{sqlite_config}", env: env
   bundle "config set force_ruby_platform true", env: env
   bundle "install", env: env
 

--- a/config/software/sqlite.rb
+++ b/config/software/sqlite.rb
@@ -16,12 +16,12 @@
 #
 
 name "sqlite"
-default_version "3.8.8.2"
+default_version "3.39.3"
 
-source :url => "https://sqlite.org/2015/sqlite-autoconf-3080802.tar.gz",
-       :md5 => "3425fa580a56880f56bcb887dd26cc06"
+source :url => "https://www.sqlite.org/2022/sqlite-autoconf-3390300.tar.gz",
+       :md5 => "b77730d5c2f8c85b223d1959d08b6514"
 
-relative_path "sqlite-autoconf-3080802"
+relative_path "sqlite-autoconf-3390300"
 
 build do
   use_bash = ""

--- a/config/software/sqlite.rb
+++ b/config/software/sqlite.rb
@@ -16,12 +16,12 @@
 #
 
 name "sqlite"
-default_version "3.39.3"
+default_version "3.8.8.2"
 
-source :url => "https://www.sqlite.org/2022/sqlite-autoconf-3390300.tar.gz",
-       :md5 => "b77730d5c2f8c85b223d1959d08b6514"
+source :url => "https://sqlite.org/2015/sqlite-autoconf-3080802.tar.gz",
+       :md5 => "3425fa580a56880f56bcb887dd26cc06"
 
-relative_path "sqlite-autoconf-3390300"
+relative_path "sqlite-autoconf-3080802"
 
 build do
   use_bash = ""


### PR DESCRIPTION
~update to sqlite 3.39.3~ to play nice with sqlite3 >= 1.5.0

This required marking the gem built artifacts to skip health check.  Comments added to clarify that `libz` is built and embedded so this should not be a problem. In fact the updated sqlite version is not required however it does provide consistency.