### PR TITLE
Upgrading jemalloc & openssl for Apple Silicon support

### DIFF
--- a/config/patches/jemalloc/jemalloc-centos-fix.patch
+++ b/config/patches/jemalloc/jemalloc-centos-fix.patch
@@ -1,0 +1,24 @@
+diff --git a/include/jemalloc/internal/pac.h b/include/jemalloc/internal/pac.h
+index 01c4e6a..9122aa0 100644
+--- a/include/jemalloc/internal/pac.h
++++ b/include/jemalloc/internal/pac.h
+@@ -74,7 +74,6 @@ struct pac_stats_s {
+        atomic_zu_t abandoned_vm;
+ };
+ 
+-typedef struct pac_s pac_t;
+ struct pac_s {
+        /*
+         * Must be the first member (we convert it to a PAC given only a
+diff --git a/include/jemalloc/internal/san_bump.h b/include/jemalloc/internal/san_bump.h
+index 8ec4a71..d5902ba 100644
+--- a/include/jemalloc/internal/san_bump.h
++++ b/include/jemalloc/internal/san_bump.h
+@@ -9,7 +9,6 @@
+ 
+ extern bool opt_retain;
+ 
+-typedef struct ehooks_s ehooks_t;
+ typedef struct pac_s pac_t;
+ 
+ typedef struct san_bump_alloc_s san_bump_alloc_t;

--- a/config/software/jemalloc.rb
+++ b/config/software/jemalloc.rb
@@ -1,13 +1,13 @@
 name "jemalloc"
 
-default_version "5.2.1"
+default_version "5.3.0"
 
 license_file "COPYING"
 
 skip_transitive_dependency_licensing true
 
-version "5.2.1" do
-  source sha256: "34330e5ce276099e2e8950d9335db5a875689a4c6a56751ef3b1d8c537f887f6"
+version "5.3.0" do
+  source sha256: "2db82d1e7119df3e71b7640219b6dfe84789bc0537983c3b7ac4f7189aecfeaa"
 end
 
 source url: "https://github.com/jemalloc/jemalloc/releases/download/#{version}/jemalloc-#{version}.tar.bz2"
@@ -17,6 +17,10 @@ relative_path "jemalloc-#{version}"
 env = with_standard_compiler_flags(with_embedded_path)
 
 build do
+  if rhel?
+    patch source: "jemalloc-centos-fix.patch", plevel: 1
+  end
+
   configure_commands = [
     "--prefix=#{install_dir}/embedded",
     "--with-jemalloc-prefix="

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -23,7 +23,7 @@ skip_transitive_dependency_licensing true
 dependency "cacerts"
 dependency "openssl-fips" if fips_mode?
 
-default_version "1.1.1f"
+default_version "1.1.1m"
 
 # Openssl builds engines as libraries into a special directory. We need to include
 # that directory in lib_dirs so omnibus can sign them during macOS deep signing.
@@ -40,6 +40,7 @@ else
   source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 end
 
+version("1.1.1m") { source sha256: "f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96" }
 version("1.1.1l") { source sha256: "0b7a3e5e59c34827fe0c3a74b7ec8baef302b98fa80088d7f9153aa16fa76bd1" }
 version("1.1.1f") { source sha256: "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" }
 


### PR DESCRIPTION
...Continued from [previous PR](https://github.com/rapid7/metasploit-omnibus/pull/181)

Packaging support for Apple Silicon.

Relevant [issue](https://github.com/rapid7/metasploit-framework/issues/17628) in metasploit-framework and [PR](https://github.com/rapid7/metasploit-omnibus-cache/pull/4) in metasploit-omnibus-cache