### PR TITLE
update config-mirror location

### DIFF
--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -18,7 +18,7 @@ name "config_guess"
 default_version "master"
 
 # Use our github mirror of the savannah repository
-source git: "https://github.com/chef/config-mirror.git"
+source git: "https://github.com/chef-boneyard/config-mirror.git"
 
 # http://savannah.gnu.org/projects/config
 license "GPL-3.0 (with exception)"


### PR DESCRIPTION
Need to do some maintenance, chef moved a repo https://github.com/chef/config-mirror is now https://github.com/chef-boneyard/config-mirror 