### PR TITLE
Update to "Deprecated APT key management utility" Ubuntu 22.04

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -61,8 +61,8 @@ install_deb() {
   LIST_FILE=/etc/apt/sources.list.d/metasploit-framework.list
   PREF_FILE=/etc/apt/preferences.d/pin-metasploit.pref
   echo -n "Adding metasploit-framework to your repository list.."
-  echo "deb $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
-  print_pgp_key | apt-key add -
+  echo "deb [signed-by=/usr/share/keyrings/metasploit-framework.gpg] $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
+  print_pgp_key | sudo gpg --dearmor -o /usr/share/keyrings/metasploit-framework.gpg
   if [ ! -f $PREF_FILE ]; then
     mkdir -p /etc/apt/preferences.d/
     cat > $PREF_FILE <<EOF


### PR DESCRIPTION
With apt-key being deprecated in Ubuntu 22.04, gpg should be used to add keys to the key rings now.

Updated code accordingly:
- "apt-key add" -> "gpg --dearmor -o /usr/share/keyrings/{file}.gpg" 
- added "signed-by" location to the /etc/apt/sourcelist file.