### PR TITLE
Test ruby 3.3 dependency build

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -4,7 +4,7 @@ if linux? && File.exist?("/metasploit-framework")
   source path: "/metasploit-framework"
 else
   source git: "https://github.com/rapid7/metasploit-framework.git"
-  default_version "master"
+  default_version "add-support-for-ruby-3.3"
 end
 
 dependency "cacerts"


### PR DESCRIPTION
Testing to ensure that the dependencies of https://github.com/rapid7/metasploit-framework/pull/18668 will build on Metasploit Omnibus