### PR TITLE
Bug fix: remove sudo from gpg command

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -62,7 +62,7 @@ install_deb() {
   PREF_FILE=/etc/apt/preferences.d/pin-metasploit.pref
   echo -n "Adding metasploit-framework to your repository list.."
   echo "deb [signed-by=/usr/share/keyrings/metasploit-framework.gpg] $DOWNLOAD_URI/apt lucid main" > $LIST_FILE
-  print_pgp_key | sudo gpg --dearmor -o /usr/share/keyrings/metasploit-framework.gpg
+  print_pgp_key | gpg --dearmor -o /usr/share/keyrings/metasploit-framework.gpg
   if [ ! -f $PREF_FILE ]; then
     mkdir -p /etc/apt/preferences.d/
     cat > $PREF_FILE <<EOF


### PR DESCRIPTION
## Changes:
- Removed `sudo` from the `gpg` command as the script already checks if a user is running as root or `sudo` in the script

## Reason:
- Including `sudo` in this command breaks the installer for non-sudo environments like containers

Since 3136e4c6b7803d2ee139f2177a0d0742f4d6b985 `msfinstall` does not work as intended for systems that do not include `sudo` by default like Docker containers. This creates errors when following installation [documentation](https://docs.rapid7.com/metasploit/installing-the-metasploit-framework/).

```
curl https://raw.githubusercontent.com/rapid7/metasploit-omnibus/master/config/templates/metasploit-framework-wrappers/msfupdate.erb > msfinstall && chmod 755 msfinstall && ./msfinstall
```