### PR TITLE
Update macos runner

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-11
+          - macos-12
         ruby:
           - 3.0.6
 


### PR DESCRIPTION
macos-11 is no longer available; updating to macos-12

![image](https://github.com/rapid7/metasploit-omnibus/assets/60357436/ffef44a3-e6e8-47a0-af8a-284f35499b5b)

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories