### PR TITLE
Ignore healthchecks on exploit files

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -40,6 +40,7 @@ whitelist_file "#{install_dir}//embedded/framework/data/exploits/.*"
 
 # This depends on libfuse
 whitelist_file "#{install_dir}/embedded/framework/data/exploits/CVE-2016-4557/hello"
+whitelist_file "#{install_dir}/embedded/framework/data/exploits/CVE-2023-0386/cve_2023_0386.x64.elf"
 
 # This depends on Openssl 1.x
 whitelist_file "#{install_dir}/embedded/lib/ruby/gems/#{ruby_abi_version}/gems/metasploit-payloads.*"


### PR DESCRIPTION
Fix the failing omnibus build:

```
12:00:01 [Project: metasploit-framework] I | 2024-10-07T11:00:01+00:00 | Building version manifest
12:00:02             [HealthCheck] I | 2024-10-07T11:00:02+00:00 | Running health on metasploit-framework
12:01:17             [HealthCheck] E | 2024-10-07T11:01:17+00:00 | Failed!
12:01:17             [HealthCheck] E | 2024-10-07T11:01:17+00:00 | The following libraries have unsafe or unmet dependencies:
12:01:17 
12:01:17             [HealthCheck] E | 2024-10-07T11:01:17+00:00 | The following binaries have unsafe or unmet dependencies:
12:01:17     --> /opt/metasploit-framework/embedded/framework/data/exploits/CVE-2023-0386/cve_2023_0386.x64.elf
12:01:17 
12:01:17             [HealthCheck] E | 2024-10-07T11:01:17+00:00 | The following requirements could not be resolved:
12:01:17     --> libfuse.so.2
12:01:17 
12:01:17             [HealthCheck] E | 2024-10-07T11:01:17+00:00 | The precise failures were:
12:01:17     --> /opt/metasploit-framework/embedded/framework/data/exploits/CVE-2023-0386/cve_2023_0386.x64.elf
12:01:17     DEPENDS ON: libfuse.so.2
12:01:17       COUNT: 1
12:01:17       PROVIDED BY: not found
12:01:17       FAILED BECAUSE: Unresolved dependency
12:01:17 
12:01:17             [HealthCheck] I | 2024-10-07T11:01:17+00:00 | Health check time: 75.2951s
12:01:17 [31mThe health check failed! Please see above for important information.
12:01:17 [0m
12:01:17 [31m
```
