### PR TITLE
Add msfconsole hardlink in msfupdate.erb 

### DIFF
--- a/config/templates/metasploit-framework-wrappers/msfupdate.erb
+++ b/config/templates/metasploit-framework-wrappers/msfupdate.erb
@@ -125,6 +125,9 @@ install_pkg()
       installer -pkg metasploitframework-latest.pkg -target /
     fi
 
+    echo "Creating alias to msfconsole..."
+    ln /opt/metasploit-framework/bin/msfconsole /usr/local/bin/msfconsole
+
     echo "Cleaning up..."
     rm -fv metasploitframework-latest.pkg
   )


### PR DESCRIPTION
Add hardlink to msfconsole (macOS) to make it easier to use from current terminal session after installation