### PR TITLE
Update macos version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -293,7 +293,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
         ruby:
           - 3.0.6
 


### PR DESCRIPTION
The macos 12 host is end of life, Github is requiring that we upgrade to 13 :+1: