### PR TITLE
Update windows bundle patch

### DIFF
--- a/config/patches/metasploit-framework/windows.patch
+++ b/config/patches/metasploit-framework/windows.patch
@@ -2,40 +2,32 @@ diff --git a/Gemfile.lock b/Gemfile.lock
 index a05bbfbdc7e..1a3cff9acc7 100644
 --- Gemfile.lock       2024-05-17 12:32:16
 +++ Gemfile.lock       2024-05-17 12:32:59
-@@ -32,8 +32,6 @@ PATH
+@@ -32,7 +32,6 @@ PATH
        faraday (= 2.7.11)
        faraday-retry
        faye-websocket
 -      ffi (< 1.17.0)
--      fiddle
+       fiddle
        filesize
        getoptlong
-       hrr_rb_ssh-ed25519
-@@ -66,7 +64,6 @@ PATH
+@@ -64,9 +63,7 @@ PATH
+       openssl-ccm
+       openvas-omp
        ostruct
-       packetfu
+-      packetfu
        patch_finder
 -      pcaprub
        pdf-reader
        pg
        puma
-@@ -262,8 +259,6 @@ GEM
-     faye-websocket (0.11.3)
-       eventmachine (>= 0.12.0)
-       websocket-driver (>= 0.5.1)
--    ffi (1.16.3)
--    fiddle (1.1.6)
-     filesize (0.2.0)
-     fivemat (1.3.7)
-     forwardable (1.3.3)
-@@ -375,14 +370,11 @@ GEM
+@@ -380,14 +377,11 @@ GEM
      openssl-cmac (2.0.2)
      openvas-omp (0.0.4)
      ostruct (0.6.1)
 -    packetfu (2.0.0)
 -      pcaprub (~> 0.13.1)
-     parallel (1.26.3)
-     parser (3.3.7.1)
+     parallel (1.27.0)
+     parser (3.3.8.0)
        ast (~> 2.4.1)
        racc
      patch_finder (1.0.2)
@@ -59,6 +51,15 @@ index 8c620476dbc..959eb1284f8 100644
    # Used by the Metasploit data model, etc.
    # bound to 0.2x for Activerecord 4.2.8 deprecation warnings:
    # https://github.com/ged/ruby-pg/commit/c90ac644e861857ae75638eb6954b1cb49617090
+@@ -154,7 +154,7 @@ Gem::Specification.new do |spec|
+   spec.add_runtime_dependency 'net-smtp'
+   spec.add_runtime_dependency 'net-sftp'
+   spec.add_runtime_dependency 'winrm'
+-  spec.add_runtime_dependency 'ffi', '< 1.17.0'
++  #spec.add_runtime_dependency 'ffi', '< 1.17.0'
+ 
+   #
+   # REX Libraries
 @@ -266,7 +266,6 @@ Gem::Specification.new do |spec|
      bigdecimal
      csv


### PR DESCRIPTION
Update windows bundle patch as it's currently faling:

```
16:14:52  Output:
16:14:52  
16:14:52      patching file Gemfile.lock
16:14:52  Hunk #4 FAILED at 370.
16:14:52  1 out of 4 hunks FAILED -- saving rejects to file Gemfile.lock.rej
16:14:52  patching file metasploit-framework.gemspec
16:14:52  
16:14:52  Error:
16:14:52  
16:14:52      (nothing)
```

Regenerated by applying only the `gemspec` changes, rerunning a bundle, and creating the new patch file