### PR TITLE
Update Ruby 3.2.8

### DIFF
--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "3.2.5-1"
+default_version "3.2.8-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
@@ -64,6 +64,10 @@ else
 
   version "3.2.5-1" do
     source sha256: "3e17f7e60834cfac4b2aae13677c19d3222b52bee328c3c22629246c00cd543c"
+  end
+
+  version "3.2.8-1" do
+    source sha256: "e37172bc960a22b1fda9603bea617625b5a1af48d009844818e85eaa00684962"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -26,7 +26,7 @@ skip_transitive_dependency_licensing true
 # the default versions should always be the latest release of ruby
 # if you consume this definition it is your responsibility to pin
 # to the desired version of ruby. don't count on this not changing.
-default_version "3.2.5"
+default_version "3.2.8"
 
 dependency "zlib"
 dependency "openssl"
@@ -43,6 +43,7 @@ dependency "ncurses" if freebsd?
 
 # version_list: url=https://cache.ruby-lang.org/pub/ruby/ filter=*.tar.gz
 
+version("3.2.8")      { source sha256: "77acdd8cfbbe1f8e573b5e6536e03c5103df989dc05fa68c70f011833c356075" }
 version("3.2.5")      { source sha256: "ef0610b498f60fb5cfd77b51adb3c10f4ca8ed9a17cb87c61e5bea314ac34a16" }
 version("3.2.2")      { source sha256: "96c57558871a6748de5bc9f274e93f4b5aad06cd8f37befa0e8d94e7b8a423bc" }
 version("3.2.0")      { source sha256: "daaa78e1360b2783f98deeceb677ad900f3a36c0ffa6e2b6b19090be77abc272" }


### PR DESCRIPTION
Update Ruby 3.2.8

Framework:
- https://github.com/rapid7/metasploit-framework/pull/20277
- https://github.com/rapid7/metasploit-omnibus-cache/pull/17
- https://github.com/rapid7/metasploit-omnibus-cache/pull/16
- https://github.com/rapid7/metasploit-omnibus/pull/230