### PR TITLE
Update openssl to lts

### DIFF
--- a/config/patches/openssl/openssl-3.2.4-do-not-install-docs.patch
+++ b/config/patches/openssl/openssl-3.2.4-do-not-install-docs.patch
@@ -1,0 +1,21 @@
+--- openssl-3.2.4/Configurations/unix-Makefile.tmpl.org	2025-03-03 12:05:33
++++ openssl-3.2.4/Configurations/unix-Makefile.tmpl	2025-03-03 12:25:17
+@@ -625,7 +625,7 @@
+ # Install helper targets #############################################
+ ##@ Installation
+
+-install: install_sw install_ssldirs {- "install_docs" if !$disabled{docs}; -} {- $disabled{fips} ? "" : "install_fips" -} ## Install software and documentation, create OpenSSL directories
++install: install_sw install_ssldirs {- $disabled{fips} ? "" : "install_fips" -}
+
+ uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled{fips} ? "" : "uninstall_fips" -} ## Uninstall software and documentation
+
+--- openssl-3.2.4/Configurations/windows-makefile.tmpl.org	2025-03-03 12:15:23
++++ openssl-3.2.4/Configurations/windows-makefile.tmpl	2025-03-03 12:23:04
+@@ -455,7 +455,7 @@
+ 	@$(ECHO) "Tests are not supported with your chosen Configure options"
+ 	@{- output_on() if !$disabled{tests}; "\@rem" -}
+
+-install: install_sw install_ssldirs {- "install_docs" if !$disabled{docs}; -} {- $disabled{fips} ? "" : "install_fips" -}
++install: install_sw install_ssldirs {- $disabled{fips} ? "" : "install_fips" -}
+
+ uninstall: {- "uninstall_docs" if !$disabled{docs}; -} uninstall_sw {- $disabled{fips} ? "" : "uninstall_fips" -}

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -21,7 +21,7 @@ license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
 # https://github.com/chef/omnibus-software/pull/2032
-default_version "3.6.0" # # do not remove - Rapid7 custom - do not remove
+default_version "3.5.5" # # do not remove - Rapid7 custom - do not remove
 
 dependency "cacerts"
 dependency "openssl-fips" if fips_mode? && !(version.satisfies?(">= 3.0.0"))
@@ -56,6 +56,8 @@ version("3.2.4") { source sha256: "b23ad7fd9f73e43ad1767e636040e88ba7c9e5775bfa5
 version("3.3.3") { source sha256: "712590fd20aaa60ec75d778fe5b810d6b829ca7fb1e530577917a131f9105539" }
 version("3.4.1") { source sha256: "002a2d6b30b58bf4bea46c43bdd96365aaf8daa6c428782aa4feee06da197df3" }
 version("3.4.4") { source sha256: "7bdf55ac20f2779e99e5eca306f824fad2b37dee5a06cc35ed5a8b85a6060010" }
+version("3.5.5") { source sha256: "b28c91532a8b65a1f983b4c28b7488174e4a01008e29ce8e69bd789f28bc2a89" }
+
 version("3.6.0") { source sha256: "b6a5f44b7eb69e3fa35dbf15524405b44837a481d43d81daddde3ff21fcbb8e9" }
 
 version("3.1.2") { source sha256: "a0ce69b8b97ea6a35b96875235aa453b966ba3cba8af2de23657d8b6767d6539" } # FIPS validated


### PR DESCRIPTION
Continuation of https://github.com/rapid7/metasploit-omnibus/pull/242 - which was focused on an MVP green build, but now we're tweaking things to test against the the latest 3.5 LTS release

Move from openssl 3.6.0 to the latest LTS version

<img width="774" height="336" alt="image" src="https://github.com/user-attachments/assets/b056dfac-37b9-4b45-b06a-2eedd5ea7dca" />

https://endoflife.date/openssl

Dependency added: https://github.com/rapid7/metasploit-omnibus-cache/pull/23