### PR TITLE
Resolve CI errors

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -138,7 +138,7 @@ jobs:
             metasploit-omnibus/pkg/*.rpm
             metasploit-omnibus/pkg/*.msi
             metasploit-omnibus/pkg/*.deb
-          retention-days: 1
+          retention-days: 7
 
   docker_intel:
     runs-on: ${{ matrix.os }}
@@ -306,7 +306,7 @@ jobs:
             metasploit-omnibus/pkg/*.rpm
             metasploit-omnibus/pkg/*.msi
             metasploit-omnibus/pkg/*.deb
-          retention-days: 1
+          retention-days: 7
 
   # Sanity check: install the built .deb on a modern Ubuntu and verify database connectivity.
   # This catches ABI mismatches (e.g. bundled libpq vs bundled OpenSSL) that only manifest
@@ -446,7 +446,7 @@ jobs:
             metasploit-omnibus/pkg/*.rpm
             metasploit-omnibus/pkg/*.msi
             metasploit-omnibus/pkg/*.deb
-          retention-days: 1
+          retention-days: 7
 
   windows:
     runs-on: ${{ matrix.os }}
@@ -550,7 +550,7 @@ jobs:
             metasploit-omnibus/pkg/*.rpm
             metasploit-omnibus/pkg/*.msi
             metasploit-omnibus/pkg/*.deb
-          retention-days: 1
+          retention-days: 7
 
   # Ensure we can install the Windows installer on a fresh environment without any pre-existing dependencies.
   # Additionally, running on the previous windows builder is not currently possible, as it currently hangs on

--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -58,6 +58,7 @@ build do
       skipped_dependencies = [
         'ruby-prof',
         'memory_profiler',
+        'license_finder',
       ]
       replacements = {
         'stringio (= 3.1.1)' => 'stringio (= 3.1.2)',
@@ -78,10 +79,30 @@ build do
 
       file_path = File.join(project_dir, gemfile)
       old_file = File.binread(file_path)
-      new_content = old_file.lines(chomp: true).reject do |line|
-        is_skipped = skipped_dependencies.any? { |skipped_dependency| line.include?(skipped_dependency) }
-        is_skipped
-      end.join("\n")
+      lines = old_file.lines(chomp: true)
+
+      # For Gemfile.lock, we need to remove entire source blocks (GIT/PATH) that
+      # contain skipped gems, and individual lines from other sections
+      if gemfile == 'Gemfile.lock'
+        blocks = old_file.split(/\r?\n\r?\n/)
+        new_content = blocks.filter_map do |block|
+          if block.start_with?('GIT', 'PATH')
+            # Drop entire source block if it contains a skipped gem
+            next nil if skipped_dependencies.any? { |dep| block.include?(dep) }
+            block
+          else
+            # Line-level filtering for DEPENDENCIES, GEM specs, etc.
+            filtered = block.lines(chomp: true).reject do |line|
+              skipped_dependencies.any? { |dep| line.include?(dep) }
+            end.join("\n")
+            filtered.empty? ? nil : filtered
+          end
+        end.join("\n\n")
+      else
+        new_content = lines.reject do |line|
+          skipped_dependencies.any? { |dep| line.include?(dep) }
+        end.join("\n")
+      end
       replacements.each { |old, new| new_content = new_content.gsub(old, new) }
 
       File.open(file_path, 'wb') { |f| f.puts(new_content) }
@@ -130,12 +151,42 @@ build do
   bundle "install --jobs=4 --verbose", env: bundle_env
 
   if windows?
-    # Ensure we additionally copy out 'libssp-0.dll', which is required for multiple gems:
-    #   > dumpbin /dependents  C:/metasploit-framework/embedded/lib/ruby/gems/3.1.0/gems/msgpack-1.6.1/lib/msgpack/msgpack.so
-    #       ...
-    #       libssp-0.dll
-    #       ...
-    copy "#{install_dir}/embedded/msys64/ucrt64/bin/libssp-0.dll", "#{install_dir}/embedded/bin/libssp-0.dll"
+    # Copy required runtime DLLs from MSYS2 ucrt64 to embedded/bin.
+    # Native gems (nokogiri, eventmachine, etc.) link against MSYS2's ucrt64
+    # libraries during bundle install. These DLLs must be available at runtime.
+    # We copy them to embedded/bin (which is in PATH) before deleting msys64.
+    msys_ucrt64_bin = "#{install_dir}/embedded/msys64/ucrt64/bin"
+    block "Copy MSYS2 runtime DLLs to embedded/bin" do
+      required_dlls = %w[
+        libxml2-2.dll
+        libiconv-2.dll
+        liblzma-5.dll
+        zlib1.dll
+        libintl-8.dll
+      ]
+      missing = []
+      required_dlls.each do |dll|
+        src = File.join(msys_ucrt64_bin, dll)
+        if File.exist?(src)
+          FileUtils.cp(src, "#{install_dir}/embedded/bin/#{dll}")
+        else
+          missing << src
+        end
+      end
+      raise "MSYS2 runtime DLLs not found:\n  #{missing.join("\n  ")}" if missing.any?
+    end
+
+    # Patch the pg gem's postgresql_lib_path.rb to disable add_dll_directory.
+    # The pg gem bakes in the compile-time absolute path to libpq which may not
+    # exist at runtime if the MSI installs to a different drive. Setting the path
+    # to false makes pg skip add_dll_directory and rely on the system PATH instead,
+    # where libpq.dll is available via embedded/bin.
+    block "Patch pg gem DLL path" do
+      pg_lib_path_file = Dir.glob("#{install_dir}/embedded/lib/ruby/gems/*/gems/pg-*/lib/pg/postgresql_lib_path.rb").first
+      if pg_lib_path_file
+        File.write(pg_lib_path_file, "module PG; POSTGRESQL_LIB_PATH = false; end\n")
+      end
+    end
 
     delete "#{install_dir}/embedded/msys64"
   end

--- a/config/software/postgresql-windows.rb
+++ b/config/software/postgresql-windows.rb
@@ -33,6 +33,25 @@ build do
 
   copy "#{project_dir}/bin/*", "#{install_dir}/embedded/bin"
   copy "#{project_dir}/lib/*", "#{install_dir}/embedded/lib"
+  # Remove OpenSSL import libraries and DLLs bundled by PostgreSQL.
+  # PostgreSQL 16.x ships OpenSSL 3.0.x which lacks symbols (e.g. EVP_MD_CTX_get_size_ex)
+  # that are present in MSYS2's OpenSSL 3.6.x headers. This causes:
+  # 1. Linker errors: MinGW finds PostgreSQL's .lib before MSYS2's .dll.a
+  # 2. Runtime LoadErrors: openssl.so calls symbols missing from the 3.0.x DLL
+  # Replace with RubyInstaller's OpenSSL DLLs (3.6.x) which match the MSYS2 headers.
+  delete "#{install_dir}/embedded/lib/libcrypto.lib"
+  delete "#{install_dir}/embedded/lib/libssl.lib"
+  delete "#{install_dir}/embedded/bin/libcrypto-3-x64.dll"
+  delete "#{install_dir}/embedded/bin/libssl-3-x64.dll"
+  block "Copy RubyInstaller OpenSSL DLLs to embedded/bin" do
+    ruby_platform_dir = Dir.glob("#{install_dir}/embedded/lib/ruby/*/x64-mingw-ucrt").first
+    raise "RubyInstaller platform dir not found under #{install_dir}/embedded/lib/ruby/" unless ruby_platform_dir
+    %w[libcrypto-3-x64.dll libssl-3-x64.dll].each do |dll|
+      src = File.join(ruby_platform_dir, dll)
+      raise "RubyInstaller OpenSSL DLL not found: #{src}" unless File.exist?(src)
+      FileUtils.cp(src, "#{install_dir}/embedded/bin/#{dll}")
+    end
+  end
   # Remove headers that conflict with other omnibus-bundled libraries before copying
   delete "#{project_dir}/include/libxml"
   delete "#{project_dir}/include/libxslt"

--- a/config/software/ruby-windows.rb
+++ b/config/software/ruby-windows.rb
@@ -15,7 +15,7 @@
 #
 
 name "ruby-windows"
-default_version "3.4.4-2"
+default_version "3.4.9-1"
 
 if windows_arch_i386?
   relative_path "rubyinstaller-#{version}-x86"
@@ -76,6 +76,14 @@ else
 
   version "3.4.4-2" do
     source sha256: "29fe655a8bee91d6466e631ae612142a1c5d68d46323ccca7f35add2dbb28b51"
+  end
+
+  version "3.4.9-1" do
+    source sha256: "4375268618b61dadf53bf8e54beaca74ea30580c90d3c47ea9f2a134bd3e494e"
+  end
+
+  version "4.0.5-1" do
+    source sha256: "74e31613fc71e6e23431dfc4d8b6ec2818a4dc1fd16e0983b074144c16719c8b"
   end
 
   source url: "https://github.com/oneclick/rubyinstaller2/releases/download/rubyinstaller-#{version}/rubyinstaller-#{version}-x64.7z"


### PR DESCRIPTION
Resolve CI errors associated with license_finder - which hits max path issues on Windows due to it being git cloned rather than pulled in as a normal rubygems gem