### PR TITLE
Fix osx build failure

### DIFF
--- a/config/software/metasploit-framework.rb
+++ b/config/software/metasploit-framework.rb
@@ -146,7 +146,10 @@ build do
   bundle "version", env: env
   bundle "config set force_ruby_platform true", env: env
   bundle_env = with_standard_compiler_flags(with_embedded_path)
-  bundle_env['MAKE'] = 'make -j4'
+  # Limit make parallelism on macOS to avoid a mini_portile2 race condition where
+  # parallel make subprocesses collide creating the sqlite3 ports directory during
+  # native extension compilation (Error 71: EEXIST).
+  bundle_env['MAKE'] = mac_os_x? ? 'make' : 'make -j4'
   bundle_env['BUNDLE_FORCE_RUBY_PLATFORM'] = 'true'
   bundle "install --jobs=4 --verbose", env: bundle_env
 


### PR DESCRIPTION
OSX currently fails on CI:

```
14:44:36 install: mkdir /opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/sqlite3-2.9.4/ports/x86_64-apple-darwin23.6.0: File exists
14:44:36 install: install: mkdir /opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/sqlite3-2.9.4/ports/x86_64-apple-darwin23.6.0: File exists
14:44:36 mkdir /opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/sqlite3-2.9.4/ports/x86_64-apple-darwin23.6.0: File exists
14:44:36 make: *** [/opt/metasploit-framework/embedded/lib/ruby/gems/3.4.0/gems/sqlite3-2.9.4/ports/x86_64-apple-darwin23.6.0/sqlite3/3.53.1/include] Error 71
```

Which we believe to be caused by mini_portile/sqlite bug when compiling in parallel